### PR TITLE
feat: add edge command dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,78 @@ Clawland Fleet is the **nervous system** connecting cloud and edge. It provides 
   └────────┘    └────────┘    └────────┘
 ```
 
+## Fleet Manager API
+
+### Register a node
+
+`POST /fleet/register` registers an edge node so commands can be queued for it.
+
+```json
+{
+  "id": "picclaw-001",
+  "name": "PicClaw 001",
+  "type": "picclaw",
+  "capabilities": ["camera", "gpio"],
+  "location": "lab-a"
+}
+```
+
+### Dispatch a command
+
+`POST /fleet/command` queues a cloud-to-edge command for a registered node.
+
+```json
+{
+  "node_id": "picclaw-001",
+  "type": "restart",
+  "payload": {
+    "reason": "maintenance"
+  }
+}
+```
+
+Supported command types are `restart`, `update_config`, `execute_skill`, and `firmware_update`.
+Queued commands start as `pending` and are tracked through `delivered`, `executed`, or `failed`.
+
+### Deliver queued commands on heartbeat
+
+`POST /fleet/heartbeat` updates the node heartbeat and returns commands queued for that node:
+
+```json
+{
+  "node_id": "picclaw-001"
+}
+```
+
+```json
+{
+  "ok": true,
+  "commands": [
+    {
+      "id": "cmd-1",
+      "node_id": "picclaw-001",
+      "type": "restart",
+      "status": "delivered"
+    }
+  ]
+}
+```
+
+Queues and command status are currently in-memory.
+
+### Update or read command status
+
+Edge nodes report execution results with `POST /fleet/command/status`:
+
+```json
+{
+  "command_id": "cmd-1",
+  "status": "executed"
+}
+```
+
+Use `GET /fleet/command?id=cmd-1` to read the latest tracked status.
+
 ## Status
 
 🚧 **Pre-Alpha** — Architecture design phase. Looking for contributors!

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -6,7 +6,10 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+
+	"github.com/Clawland-AI/clawland-fleet/pkg/fleet"
 )
 
 const version = "0.1.0"
@@ -22,4 +25,7 @@ func main() {
 	fmt.Println("   Waiting for edge agent registrations...")
 
 	log.Printf("Fleet Manager listening on :%s", port)
+	registry := fleet.NewRegistry()
+	dispatcher := fleet.NewDispatcher()
+	log.Fatal(http.ListenAndServe(":"+port, fleet.NewServer(registry, dispatcher)))
 }

--- a/pkg/fleet/dispatcher.go
+++ b/pkg/fleet/dispatcher.go
@@ -1,0 +1,203 @@
+package fleet
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// CommandType is a cloud-to-edge command kind.
+type CommandType string
+
+const (
+	CommandTypeRestart        CommandType = "restart"
+	CommandTypeUpdateConfig   CommandType = "update_config"
+	CommandTypeExecuteSkill   CommandType = "execute_skill"
+	CommandTypeFirmwareUpdate CommandType = "firmware_update"
+)
+
+// CommandStatus tracks command progress through the edge delivery lifecycle.
+type CommandStatus string
+
+const (
+	CommandStatusPending   CommandStatus = "pending"
+	CommandStatusDelivered CommandStatus = "delivered"
+	CommandStatusExecuted  CommandStatus = "executed"
+	CommandStatusFailed    CommandStatus = "failed"
+)
+
+var (
+	ErrEmptyNodeID        = errors.New("node_id is required")
+	ErrInvalidCommandType = errors.New("invalid command type")
+	ErrInvalidStatus      = errors.New("invalid command status")
+	ErrCommandNotFound    = errors.New("command not found")
+)
+
+// Command is a command queued by the Fleet Manager for an edge node.
+type Command struct {
+	ID          string         `json:"id"`
+	NodeID      string         `json:"node_id"`
+	Type        CommandType    `json:"type"`
+	Payload     map[string]any `json:"payload,omitempty"`
+	Status      CommandStatus  `json:"status"`
+	Error       string         `json:"error,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	DeliveredAt *time.Time     `json:"delivered_at,omitempty"`
+	ExecutedAt  *time.Time     `json:"executed_at,omitempty"`
+}
+
+// Dispatcher stores per-node command queues and command status.
+type Dispatcher struct {
+	mu       sync.RWMutex
+	nextID   uint64
+	queues   map[string][]string
+	commands map[string]*Command
+}
+
+// NewDispatcher creates an in-memory command dispatcher.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{
+		queues:   make(map[string][]string),
+		commands: make(map[string]*Command),
+	}
+}
+
+// Dispatch queues a command for delivery to a specific node.
+func (d *Dispatcher) Dispatch(nodeID string, commandType CommandType, payload map[string]any) (Command, error) {
+	if nodeID == "" {
+		return Command{}, ErrEmptyNodeID
+	}
+	if !validCommandType(commandType) {
+		return Command{}, ErrInvalidCommandType
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.nextID++
+	command := &Command{
+		ID:        fmt.Sprintf("cmd-%d", d.nextID),
+		NodeID:    nodeID,
+		Type:      commandType,
+		Payload:   clonePayload(payload),
+		Status:    CommandStatusPending,
+		CreatedAt: time.Now(),
+	}
+	d.commands[command.ID] = command
+	d.queues[nodeID] = append(d.queues[nodeID], command.ID)
+
+	return cloneCommand(command), nil
+}
+
+// DeliverPending marks queued commands as delivered and returns them.
+func (d *Dispatcher) DeliverPending(nodeID string) []Command {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	ids := d.queues[nodeID]
+	delete(d.queues, nodeID)
+
+	now := time.Now()
+	commands := make([]Command, 0, len(ids))
+	for _, id := range ids {
+		command, ok := d.commands[id]
+		if !ok || command.Status != CommandStatusPending {
+			continue
+		}
+		command.Status = CommandStatusDelivered
+		command.DeliveredAt = &now
+		commands = append(commands, cloneCommand(command))
+	}
+	return commands
+}
+
+// UpdateStatus records the latest edge-reported command status.
+func (d *Dispatcher) UpdateStatus(commandID string, status CommandStatus, message string) error {
+	if !validCommandStatus(status) {
+		return ErrInvalidStatus
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	command, ok := d.commands[commandID]
+	if !ok {
+		return ErrCommandNotFound
+	}
+
+	command.Status = status
+	switch status {
+	case CommandStatusDelivered:
+		if command.DeliveredAt == nil {
+			now := time.Now()
+			command.DeliveredAt = &now
+		}
+	case CommandStatusExecuted:
+		now := time.Now()
+		command.ExecutedAt = &now
+		command.Error = ""
+	case CommandStatusFailed:
+		now := time.Now()
+		command.ExecutedAt = &now
+		command.Error = message
+	}
+	return nil
+}
+
+// Command returns a command by ID.
+func (d *Dispatcher) Command(commandID string) (Command, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	command, ok := d.commands[commandID]
+	if !ok {
+		return Command{}, false
+	}
+	return cloneCommand(command), true
+}
+
+func validCommandType(commandType CommandType) bool {
+	switch commandType {
+	case CommandTypeRestart, CommandTypeUpdateConfig, CommandTypeExecuteSkill, CommandTypeFirmwareUpdate:
+		return true
+	default:
+		return false
+	}
+}
+
+func validCommandStatus(status CommandStatus) bool {
+	switch status {
+	case CommandStatusPending, CommandStatusDelivered, CommandStatusExecuted, CommandStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func cloneCommand(command *Command) Command {
+	copied := *command
+	copied.Payload = clonePayload(command.Payload)
+	copied.DeliveredAt = cloneTime(command.DeliveredAt)
+	copied.ExecutedAt = cloneTime(command.ExecutedAt)
+	return copied
+}
+
+func clonePayload(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	copied := make(map[string]any, len(payload))
+	for key, value := range payload {
+		copied[key] = value
+	}
+	return copied
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copied := *value
+	return &copied
+}

--- a/pkg/fleet/dispatcher_test.go
+++ b/pkg/fleet/dispatcher_test.go
@@ -1,0 +1,100 @@
+package fleet
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDispatcherQueuesCommandsPerNode(t *testing.T) {
+	dispatcher := NewDispatcher()
+
+	first, err := dispatcher.Dispatch("node-1", CommandTypeRestart, map[string]any{"reason": "maintenance"})
+	if err != nil {
+		t.Fatalf("dispatch first command: %v", err)
+	}
+	second, err := dispatcher.Dispatch("node-2", CommandTypeUpdateConfig, map[string]any{"interval": "30s"})
+	if err != nil {
+		t.Fatalf("dispatch second command: %v", err)
+	}
+
+	if first.ID == "" {
+		t.Fatal("expected command ID to be set")
+	}
+	if first.Status != CommandStatusPending {
+		t.Fatalf("expected first command status %q, got %q", CommandStatusPending, first.Status)
+	}
+
+	delivered := dispatcher.DeliverPending("node-1")
+	if len(delivered) != 1 {
+		t.Fatalf("expected 1 command for node-1, got %d", len(delivered))
+	}
+	if delivered[0].ID != first.ID {
+		t.Fatalf("expected delivered command %q, got %q", first.ID, delivered[0].ID)
+	}
+	if delivered[0].Status != CommandStatusDelivered {
+		t.Fatalf("expected delivered status %q, got %q", CommandStatusDelivered, delivered[0].Status)
+	}
+	if delivered[0].DeliveredAt == nil {
+		t.Fatal("expected delivered timestamp to be set")
+	}
+
+	if again := dispatcher.DeliverPending("node-1"); len(again) != 0 {
+		t.Fatalf("expected node-1 queue to be empty after delivery, got %d", len(again))
+	}
+
+	remaining := dispatcher.DeliverPending("node-2")
+	if len(remaining) != 1 || remaining[0].ID != second.ID {
+		t.Fatalf("expected node-2 command %q to remain queued, got %#v", second.ID, remaining)
+	}
+}
+
+func TestDispatcherRejectsUnsupportedCommandType(t *testing.T) {
+	dispatcher := NewDispatcher()
+
+	_, err := dispatcher.Dispatch("node-1", CommandType("shutdown"), nil)
+
+	if !errors.Is(err, ErrInvalidCommandType) {
+		t.Fatalf("expected ErrInvalidCommandType, got %v", err)
+	}
+}
+
+func TestDispatcherTracksExecutedAndFailedStatuses(t *testing.T) {
+	dispatcher := NewDispatcher()
+	command, err := dispatcher.Dispatch("node-1", CommandTypeExecuteSkill, map[string]any{"skill": "inspect"})
+	if err != nil {
+		t.Fatalf("dispatch command: %v", err)
+	}
+
+	dispatcher.DeliverPending("node-1")
+	if err := dispatcher.UpdateStatus(command.ID, CommandStatusExecuted, ""); err != nil {
+		t.Fatalf("update executed status: %v", err)
+	}
+	executed, ok := dispatcher.Command(command.ID)
+	if !ok {
+		t.Fatalf("expected command %q to exist", command.ID)
+	}
+	if executed.Status != CommandStatusExecuted {
+		t.Fatalf("expected status %q, got %q", CommandStatusExecuted, executed.Status)
+	}
+	if executed.ExecutedAt == nil {
+		t.Fatal("expected executed timestamp to be set")
+	}
+
+	failed, err := dispatcher.Dispatch("node-1", CommandTypeFirmwareUpdate, nil)
+	if err != nil {
+		t.Fatalf("dispatch failed command: %v", err)
+	}
+	if err := dispatcher.UpdateStatus(failed.ID, CommandStatusFailed, "firmware checksum mismatch"); err != nil {
+		t.Fatalf("update failed status: %v", err)
+	}
+	got, ok := dispatcher.Command(failed.ID)
+	if !ok {
+		t.Fatalf("expected failed command %q to exist", failed.ID)
+	}
+	if got.Status != CommandStatusFailed {
+		t.Fatalf("expected status %q, got %q", CommandStatusFailed, got.Status)
+	}
+	if got.Error != "firmware checksum mismatch" {
+		t.Fatalf("expected failure error to be recorded, got %q", got.Error)
+	}
+}

--- a/pkg/fleet/registry.go
+++ b/pkg/fleet/registry.go
@@ -50,6 +50,14 @@ func (r *Registry) Heartbeat(nodeID string) bool {
 	return false
 }
 
+// Get returns a registered node by ID.
+func (r *Registry) Get(nodeID string) (*Node, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	node, ok := r.nodes[nodeID]
+	return node, ok
+}
+
 // List returns all registered nodes.
 func (r *Registry) List() []*Node {
 	r.mu.RLock()

--- a/pkg/fleet/server.go
+++ b/pkg/fleet/server.go
@@ -1,0 +1,205 @@
+package fleet
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// Server exposes Fleet Manager HTTP endpoints.
+type Server struct {
+	registry   *Registry
+	dispatcher *Dispatcher
+	mux        *http.ServeMux
+}
+
+// NewServer creates a Fleet Manager HTTP server.
+func NewServer(registry *Registry, dispatcher *Dispatcher) *Server {
+	if registry == nil {
+		registry = NewRegistry()
+	}
+	if dispatcher == nil {
+		dispatcher = NewDispatcher()
+	}
+
+	server := &Server{
+		registry:   registry,
+		dispatcher: dispatcher,
+		mux:        http.NewServeMux(),
+	}
+	server.mux.HandleFunc("/fleet/command", server.handleCommand)
+	server.mux.HandleFunc("/fleet/command/status", server.handleCommandStatus)
+	server.mux.HandleFunc("/fleet/heartbeat", server.handleHeartbeat)
+	server.mux.HandleFunc("/fleet/register", server.handleRegister)
+	return server
+}
+
+// ServeHTTP routes Fleet Manager API requests.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+type commandRequest struct {
+	NodeID  string         `json:"node_id"`
+	Type    CommandType    `json:"type"`
+	Payload map[string]any `json:"payload,omitempty"`
+}
+
+type heartbeatRequest struct {
+	NodeID string `json:"node_id"`
+}
+
+type commandStatusRequest struct {
+	CommandID string        `json:"command_id"`
+	Status    CommandStatus `json:"status"`
+	Error     string        `json:"error,omitempty"`
+}
+
+type heartbeatResponse struct {
+	OK       bool      `json:"ok"`
+	Commands []Command `json:"commands"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func (s *Server) handleCommand(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		s.handleGetCommand(w, r)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodGet+", "+http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+
+	var request commandRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON body"})
+		return
+	}
+	if request.NodeID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: ErrEmptyNodeID.Error()})
+		return
+	}
+	if !validCommandType(request.Type) {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: ErrInvalidCommandType.Error()})
+		return
+	}
+	if _, ok := s.registry.Get(request.NodeID); !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "node not found"})
+		return
+	}
+
+	command, err := s.dispatcher.Dispatch(request.NodeID, request.Type, request.Payload)
+	if err != nil {
+		status := http.StatusBadRequest
+		if !errors.Is(err, ErrEmptyNodeID) && !errors.Is(err, ErrInvalidCommandType) {
+			status = http.StatusInternalServerError
+		}
+		writeJSON(w, status, errorResponse{Error: err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, command)
+}
+
+func (s *Server) handleGetCommand(w http.ResponseWriter, r *http.Request) {
+	commandID := r.URL.Query().Get("id")
+	if commandID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "command id is required"})
+		return
+	}
+	command, ok := s.dispatcher.Command(commandID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: ErrCommandNotFound.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, command)
+}
+
+func (s *Server) handleCommandStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+
+	var request commandStatusRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON body"})
+		return
+	}
+	if request.CommandID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "command_id is required"})
+		return
+	}
+	if err := s.dispatcher.UpdateStatus(request.CommandID, request.Status, request.Error); err != nil {
+		status := http.StatusBadRequest
+		if errors.Is(err, ErrCommandNotFound) {
+			status = http.StatusNotFound
+		}
+		writeJSON(w, status, errorResponse{Error: err.Error()})
+		return
+	}
+
+	command, _ := s.dispatcher.Command(request.CommandID)
+	writeJSON(w, http.StatusOK, command)
+}
+
+func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+
+	var request heartbeatRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON body"})
+		return
+	}
+	if request.NodeID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: ErrEmptyNodeID.Error()})
+		return
+	}
+	if ok := s.registry.Heartbeat(request.NodeID); !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "node not found"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, heartbeatResponse{
+		OK:       true,
+		Commands: s.dispatcher.DeliverPending(request.NodeID),
+	})
+}
+
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+
+	var node Node
+	if err := json.NewDecoder(r.Body).Decode(&node); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON body"})
+		return
+	}
+	if node.ID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "id is required"})
+		return
+	}
+
+	s.registry.Register(&node)
+	writeJSON(w, http.StatusCreated, node)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/pkg/fleet/server_test.go
+++ b/pkg/fleet/server_test.go
@@ -1,0 +1,151 @@
+package fleet
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestServerDispatchesCommandAndDeliversOnHeartbeat(t *testing.T) {
+	dispatcher := NewDispatcher()
+	server := NewServer(NewRegistry(), dispatcher)
+
+	register := httptest.NewRequest(http.MethodPost, "/fleet/register", bytes.NewBufferString(`{"id":"node-1","name":"PicClaw 1","type":"picclaw"}`))
+	register.Header.Set("Content-Type", "application/json")
+	registerResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(registerResponse, register)
+
+	if registerResponse.Code != http.StatusCreated {
+		t.Fatalf("expected register status %d, got %d: %s", http.StatusCreated, registerResponse.Code, registerResponse.Body.String())
+	}
+
+	body := bytes.NewBufferString(`{"node_id":"node-1","type":"restart","payload":{"reason":"test"}}`)
+	request := httptest.NewRequest(http.MethodPost, "/fleet/command", body)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusAccepted, response.Code, response.Body.String())
+	}
+	rawCommand := response.Body.String()
+	if strings.Contains(rawCommand, "delivered_at") || strings.Contains(rawCommand, "executed_at") {
+		t.Fatalf("expected pending command to omit unset timestamps, got %s", rawCommand)
+	}
+	var command Command
+	if err := json.NewDecoder(strings.NewReader(rawCommand)).Decode(&command); err != nil {
+		t.Fatalf("decode command response: %v", err)
+	}
+	if command.NodeID != "node-1" {
+		t.Fatalf("expected node_id node-1, got %q", command.NodeID)
+	}
+	if command.Type != CommandTypeRestart {
+		t.Fatalf("expected command type %q, got %q", CommandTypeRestart, command.Type)
+	}
+	if command.Status != CommandStatusPending {
+		t.Fatalf("expected status %q, got %q", CommandStatusPending, command.Status)
+	}
+
+	heartbeat := httptest.NewRequest(http.MethodPost, "/fleet/heartbeat", bytes.NewBufferString(`{"node_id":"node-1"}`))
+	heartbeat.Header.Set("Content-Type", "application/json")
+	heartbeatResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(heartbeatResponse, heartbeat)
+
+	if heartbeatResponse.Code != http.StatusOK {
+		t.Fatalf("expected heartbeat status %d, got %d: %s", http.StatusOK, heartbeatResponse.Code, heartbeatResponse.Body.String())
+	}
+	var heartbeatBody struct {
+		OK       bool      `json:"ok"`
+		Commands []Command `json:"commands"`
+	}
+	if err := json.NewDecoder(heartbeatResponse.Body).Decode(&heartbeatBody); err != nil {
+		t.Fatalf("decode heartbeat response: %v", err)
+	}
+	if !heartbeatBody.OK {
+		t.Fatal("expected heartbeat ok")
+	}
+	if len(heartbeatBody.Commands) != 1 {
+		t.Fatalf("expected 1 delivered command, got %d", len(heartbeatBody.Commands))
+	}
+	if heartbeatBody.Commands[0].ID != command.ID {
+		t.Fatalf("expected delivered command %q, got %q", command.ID, heartbeatBody.Commands[0].ID)
+	}
+	if heartbeatBody.Commands[0].Status != CommandStatusDelivered {
+		t.Fatalf("expected delivered status %q, got %q", CommandStatusDelivered, heartbeatBody.Commands[0].Status)
+	}
+
+	stored, ok := dispatcher.Command(command.ID)
+	if !ok {
+		t.Fatalf("expected command %q to be stored", command.ID)
+	}
+	if stored.Status != CommandStatusDelivered {
+		t.Fatalf("expected stored status %q, got %q", CommandStatusDelivered, stored.Status)
+	}
+}
+
+func TestServerUpdatesAndReadsCommandStatus(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&Node{ID: "node-1", Name: "PicClaw 1", Type: "picclaw"})
+	dispatcher := NewDispatcher()
+	server := NewServer(registry, dispatcher)
+	command, err := dispatcher.Dispatch("node-1", CommandTypeExecuteSkill, map[string]any{"skill": "inspect"})
+	if err != nil {
+		t.Fatalf("dispatch command: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"command_id":"` + command.ID + `","status":"failed","error":"skill not found"}`)
+	request := httptest.NewRequest(http.MethodPost, "/fleet/command/status", body)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected status update code %d, got %d: %s", http.StatusOK, response.Code, response.Body.String())
+	}
+	var updated Command
+	if err := json.NewDecoder(response.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode status response: %v", err)
+	}
+	if updated.Status != CommandStatusFailed {
+		t.Fatalf("expected status %q, got %q", CommandStatusFailed, updated.Status)
+	}
+	if updated.Error != "skill not found" {
+		t.Fatalf("expected failure error to be recorded, got %q", updated.Error)
+	}
+
+	get := httptest.NewRequest(http.MethodGet, "/fleet/command?id="+command.ID, nil)
+	getResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(getResponse, get)
+
+	if getResponse.Code != http.StatusOK {
+		t.Fatalf("expected get status %d, got %d: %s", http.StatusOK, getResponse.Code, getResponse.Body.String())
+	}
+	var got Command
+	if err := json.NewDecoder(getResponse.Body).Decode(&got); err != nil {
+		t.Fatalf("decode command response: %v", err)
+	}
+	if got.Status != CommandStatusFailed || got.Error != "skill not found" {
+		t.Fatalf("expected failed command with error, got %#v", got)
+	}
+}
+
+func TestServerRejectsCommandForUnknownNode(t *testing.T) {
+	server := NewServer(NewRegistry(), NewDispatcher())
+
+	request := httptest.NewRequest(http.MethodPost, "/fleet/command", bytes.NewBufferString(`{"node_id":"missing","type":"restart"}`))
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNotFound, response.Code, response.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add an in-memory command dispatcher with per-node queues
- support `restart`, `update_config`, `execute_skill`, and `firmware_update` command types
- track command status through `pending`, `delivered`, `executed`, and `failed`
- expose HTTP endpoints for node registration, command dispatch, heartbeat delivery, status updates, and status reads
- wire the Fleet Manager binary to serve the API and document request examples

Closes #5

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- manual smoke test: register node -> dispatch command -> heartbeat delivers command -> report executed status -> read command status

Note: `go test -race ./...` could not run in this Windows environment because cgo requires a C compiler and `gcc` is not installed.