### PR TITLE
docs: add Fleet API spec and deployment diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Clawland Fleet is the **nervous system** connecting cloud and edge. It provides 
 
 ## Architecture
 
+Fleet protocol and deployment references:
+
+- [Fleet Manager OpenAPI specification](api/fleet.openapi.yaml)
+- [Deployment architecture diagrams](docs/deployment-architecture.md)
+
 ```
 ┌─────────────────────────────────────────┐
 │           Fleet Manager (Cloud)          │

--- a/api/fleet.openapi.yaml
+++ b/api/fleet.openapi.yaml
@@ -1,0 +1,374 @@
+openapi: 3.0.3
+info:
+  title: Clawland Fleet Manager API
+  version: 0.1.0
+  description: >
+    Cloud-edge control plane API used by PicoClaw, MicroClaw, NanoClaw, and
+    MoltClaw agents to register nodes, report health and events, and receive
+    commands.
+servers:
+  - url: http://localhost:8080
+    description: Local development Fleet Manager
+tags:
+  - name: Nodes
+    description: Edge node registration, heartbeat, and inventory
+  - name: Events
+    description: Edge event reporting
+  - name: Commands
+    description: Cloud-to-edge command dispatch
+paths:
+  /fleet/register:
+    post:
+      tags: [Nodes]
+      summary: Register or refresh an edge node
+      operationId: registerNode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NodeRegistrationRequest"
+            examples:
+              picclaw:
+                value:
+                  node_id: picclaw-rack-a1
+                  name: Rack A1 PicClaw
+                  type: picclaw
+                  capabilities: [temperature, humidity, relay-control]
+                  location:
+                    site: dc-1
+                    zone: rack-a
+      responses:
+        "201":
+          description: Node registered and marked online
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Node"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /fleet/heartbeat:
+    post:
+      tags: [Nodes]
+      summary: Update node liveness and metrics
+      operationId: heartbeatNode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HeartbeatRequest"
+            examples:
+              healthy:
+                value:
+                  node_id: picclaw-rack-a1
+                  status: online
+                  metrics:
+                    cpu_pct: 12.5
+                    memory_mb: 7.4
+                    queue_depth: 0
+      responses:
+        "200":
+          description: Heartbeat accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HeartbeatResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /fleet/events:
+    post:
+      tags: [Events]
+      summary: Report a sensor, alert, or lifecycle event
+      operationId: reportEvent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EventRequest"
+            examples:
+              thresholdAlert:
+                value:
+                  node_id: picclaw-rack-a1
+                  type: temperature_warning
+                  timestamp: "2026-02-16T00:00:00Z"
+                  data:
+                    temperature_c: 38.4
+                    threshold_c: 35
+      responses:
+        "202":
+          description: Event accepted for storage and downstream processing
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventAccepted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /fleet/command:
+    post:
+      tags: [Commands]
+      summary: Dispatch a command to an edge node
+      operationId: dispatchCommand
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommandRequest"
+            examples:
+              restart:
+                value:
+                  node_id: picclaw-rack-a1
+                  type: restart
+                  payload:
+                    reason: watchdog timeout
+      responses:
+        "202":
+          description: Command queued for the target node
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Command"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /fleet/nodes:
+    get:
+      tags: [Nodes]
+      summary: List registered nodes
+      operationId: listNodes
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: Optional status filter.
+          schema:
+            $ref: "#/components/schemas/NodeStatus"
+      responses:
+        "200":
+          description: Node inventory
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [nodes]
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Node"
+
+  /fleet/nodes/{id}:
+    get:
+      tags: [Nodes]
+      summary: Fetch a single node by ID
+      operationId: getNode
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          example: picclaw-rack-a1
+      responses:
+        "200":
+          description: Node details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Node"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+components:
+  responses:
+    BadRequest:
+      description: Request body is malformed or missing required fields
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: Referenced node or command does not exist
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
+  schemas:
+    NodeType:
+      type: string
+      enum: [picclaw, microclaw, nanoclaw, moltclaw]
+    NodeStatus:
+      type: string
+      enum: [online, degraded, offline]
+    NodeRegistrationRequest:
+      type: object
+      required: [node_id, capabilities]
+      properties:
+        node_id:
+          type: string
+          minLength: 1
+        name:
+          type: string
+        type:
+          $ref: "#/components/schemas/NodeType"
+        capabilities:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        location:
+          type: object
+          additionalProperties:
+            type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    HeartbeatRequest:
+      type: object
+      required: [node_id]
+      properties:
+        node_id:
+          type: string
+          minLength: 1
+        status:
+          $ref: "#/components/schemas/NodeStatus"
+        metrics:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: number
+              - type: string
+              - type: boolean
+    HeartbeatResponse:
+      type: object
+      required: [ok, node]
+      properties:
+        ok:
+          type: boolean
+        node:
+          $ref: "#/components/schemas/Node"
+        commands:
+          type: array
+          description: Commands ready for delivery to the node.
+          items:
+            $ref: "#/components/schemas/Command"
+    EventRequest:
+      type: object
+      required: [node_id, type, data]
+      properties:
+        node_id:
+          type: string
+          minLength: 1
+        type:
+          type: string
+          minLength: 1
+        timestamp:
+          type: string
+          format: date-time
+        data:
+          type: object
+          additionalProperties: true
+    EventAccepted:
+      type: object
+      required: [ok, event_id]
+      properties:
+        ok:
+          type: boolean
+        event_id:
+          type: string
+        stored_at:
+          type: string
+          format: date-time
+    CommandRequest:
+      type: object
+      required: [node_id, type]
+      properties:
+        node_id:
+          type: string
+          minLength: 1
+        type:
+          type: string
+          enum: [restart, execute_skill, update_config, gpio_write]
+        payload:
+          type: object
+          additionalProperties: true
+    Command:
+      type: object
+      required: [id, node_id, type, status, created_at]
+      properties:
+        id:
+          type: string
+        node_id:
+          type: string
+        type:
+          type: string
+        status:
+          type: string
+          enum: [pending, delivered, running, succeeded, failed]
+        payload:
+          type: object
+          additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+        delivered_at:
+          type: string
+          format: date-time
+        executed_at:
+          type: string
+          format: date-time
+        error:
+          type: string
+    Node:
+      type: object
+      required: [node_id, capabilities, status, last_seen]
+      properties:
+        node_id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: "#/components/schemas/NodeType"
+        capabilities:
+          type: array
+          items:
+            type: string
+        location:
+          type: object
+          additionalProperties:
+            type: string
+        status:
+          $ref: "#/components/schemas/NodeStatus"
+        last_seen:
+          type: string
+          format: date-time
+        metrics:
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: number
+              - type: string
+              - type: boolean
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string

--- a/docs/deployment-architecture.md
+++ b/docs/deployment-architecture.md
@@ -1,0 +1,112 @@
+# Clawland Fleet Deployment Architecture
+
+This document maps the production topology for a Clawland installation, from
+sensor-level agents through the regional gateway and up to the cloud Fleet
+Manager.
+
+## L1 → L2 → L3 data flow
+
+```mermaid
+flowchart TB
+  subgraph L1["L1 edge and sensor layer"]
+    Micro["MicroClaw MCU\nDHT22, dissolved oxygen,\nvibration, smoke"]
+    Pico["PicoClaw edge agent\nlocal rules + GPIO/relay"]
+  end
+
+  subgraph L2["L2 site gateway"]
+    Nano["NanoClaw Raspberry Pi / SBC\naggregation + offline decisions"]
+  end
+
+  subgraph L3["L3 cloud control plane"]
+    Fleet["Clawland Fleet Manager\nregistry, events, commands"]
+    Molt["MoltClaw cloud gateway\nLLM routing + orchestration"]
+    Dash["Dashboard / alerts\nGrafana, Feishu, Telegram"]
+  end
+
+  Micro -->|"sensor frames\nMQTT/serial/LoRa"| Pico
+  Pico -->|"events + heartbeat\nHTTP/MQTT"| Nano
+  Nano -->|"normalized events\n/fleet/events"| Fleet
+  Fleet -->|"command queue\n/fleet/command"| Nano
+  Nano -->|"local dispatch"| Pico
+  Fleet --> Molt
+  Fleet --> Dash
+```
+
+## Network topology options
+
+```mermaid
+flowchart LR
+  subgraph Site["Factory, data center, pond, or greenhouse"]
+    Sensors["Sensors + relays"]
+    Micro["MicroClaw"]
+    Pico["PicoClaw"]
+    Nano["NanoClaw gateway"]
+    Sensors --- Micro
+    Micro -->|"UART/I2C/SPI"| Pico
+    Pico -->|"LAN Wi-Fi/Ethernet"| Nano
+  end
+
+  subgraph Backhaul["Backhaul choices"]
+    LAN["LAN/VPN"]
+    Cell["4G/5G router"]
+    LoRa["LoRa gateway\nlow bandwidth fallback"]
+  end
+
+  subgraph Cloud["Cloud region"]
+    Fleet["Fleet Manager"]
+    Store["event store / metrics"]
+    Alert["alert channels"]
+  end
+
+  Nano --> LAN --> Fleet
+  Nano --> Cell --> Fleet
+  Micro -. "critical telemetry" .-> LoRa -.-> Fleet
+  Fleet --> Store
+  Fleet --> Alert
+```
+
+## Component interaction sequence
+
+```mermaid
+sequenceDiagram
+  participant Edge as PicoClaw / NanoClaw
+  participant Fleet as Fleet Manager
+  participant Operator as Operator dashboard
+
+  Edge->>Fleet: POST /fleet/register
+  Fleet-->>Edge: 201 node registered
+  loop every heartbeat interval
+    Edge->>Fleet: POST /fleet/heartbeat
+    Fleet-->>Edge: 200 ok + pending commands
+  end
+  Edge->>Fleet: POST /fleet/events
+  Fleet-->>Edge: 202 accepted
+  Operator->>Fleet: POST /fleet/command
+  Fleet-->>Operator: 202 command queued
+  Edge->>Fleet: POST /fleet/heartbeat
+  Fleet-->>Edge: pending command payload
+  Edge->>Fleet: POST /fleet/command/status
+  Fleet-->>Edge: 200 status recorded
+```
+
+## Failure scenarios and fallback paths
+
+| Scenario | Detection | Fallback behavior | Recovery signal |
+| --- | --- | --- | --- |
+| L1 sensor stops reporting | PicoClaw misses sensor read deadline | PicoClaw reports a `sensor_stale` event and keeps last known safe actuator state | Sensor read succeeds again |
+| PicoClaw loses WAN access | Fleet heartbeat timeout marks node offline | NanoClaw stores events locally and applies offline decision rules | Next successful heartbeat |
+| NanoClaw gateway fails | Fleet stops seeing all site nodes | PicoClaw continues local threshold actions and buffers events | Gateway registration refresh |
+| Cloud Fleet Manager unavailable | Edge HTTP requests fail or time out | Edge agents keep a bounded store-and-forward queue and retry with backoff | `/fleet/heartbeat` returns 200 |
+| Command delivery fails | Command remains pending past TTL | Fleet marks command failed and emits an operator alert | Command status update or replacement command |
+
+```mermaid
+flowchart TD
+  Healthy["Normal operation"] --> MissedHeartbeat{"heartbeat timeout?"}
+  MissedHeartbeat -- "no" --> Healthy
+  MissedHeartbeat -- "yes" --> Offline["mark node offline"]
+  Offline --> LocalRules["edge runs local rules\nand buffers events"]
+  LocalRules --> Retry{"backoff retry succeeds?"}
+  Retry -- "no" --> LocalRules
+  Retry -- "yes" --> Reconcile["flush buffered events\nand reconcile command status"]
+  Reconcile --> Healthy
+```


### PR DESCRIPTION
## Summary
- adds `api/fleet.openapi.yaml` with the Fleet Manager OpenAPI 3.0 contract for registration, heartbeat, events, command dispatch, and node inventory
- adds `docs/deployment-architecture.md` with Mermaid data-flow, topology, sequence, and failure/fallback diagrams
- links both references from the README Architecture section

Closes #1.
Closes #4.

## Verification
- `python - <<PY ... yaml.safe_load(api/fleet.openapi.yaml) ...` parsed 6 paths / 11 schemas
- `go test ./...`
- `go vet ./...`
- `go build ./...`