### PR TITLE
feat: add Fleet node and event services

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ Clawland Fleet is the **nervous system** connecting cloud and edge. It provides 
 - **Health Dashboard** — Real-time monitoring with alerting
 - **OTA Orchestrator** — Rolling firmware/skill updates with rollback
 
+Implemented Fleet Manager endpoints:
+
+- `POST /fleet/register` — register or refresh edge nodes
+- `POST /fleet/heartbeat` — update node status and metrics
+- `GET /fleet/nodes` — list active or offline nodes
+- `GET /fleet/nodes/{id}` — fetch one node
+- `POST /fleet/events` — report sensor, alert, or lifecycle events
+- `GET /fleet/events?node_id=X&type=Y&since=Z` — query the bounded event buffer
+
 ### Edge API Server (runs on PicClaw)
 - **REST/gRPC API** — Receive commands from cloud
 - **Local Task Queue** — Buffer commands during offline periods

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -6,7 +6,10 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+
+	"github.com/Clawland-AI/clawland-fleet/pkg/fleet"
 )
 
 const version = "0.1.0"
@@ -22,4 +25,6 @@ func main() {
 	fmt.Println("   Waiting for edge agent registrations...")
 
 	log.Printf("Fleet Manager listening on :%s", port)
+	server := fleet.NewServer(fleet.NewRegistry(), fleet.NewEventHub(1000))
+	log.Fatal(http.ListenAndServe(":"+port, server))
 }

--- a/pkg/fleet/events.go
+++ b/pkg/fleet/events.go
@@ -1,0 +1,92 @@
+package fleet
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var (
+	ErrEmptyEventNodeID = errors.New("node_id is required")
+	ErrEmptyEventType   = errors.New("event type is required")
+)
+
+// Event represents a normalized edge event.
+type Event struct {
+	ID        string         `json:"id"`
+	NodeID    string         `json:"node_id"`
+	Type      string         `json:"type"`
+	Data      map[string]any `json:"data"`
+	Timestamp time.Time      `json:"timestamp"`
+}
+
+// EventFilter selects events from the in-memory event buffer.
+type EventFilter struct {
+	NodeID string
+	Type   string
+	Since  time.Time
+}
+
+// EventHub stores recent events in a bounded ring buffer.
+type EventHub struct {
+	mu     sync.RWMutex
+	limit  int
+	nextID int
+	events []Event
+}
+
+// NewEventHub creates a bounded in-memory event hub.
+func NewEventHub(limit int) *EventHub {
+	if limit <= 0 {
+		limit = 1000
+	}
+	return &EventHub{limit: limit, events: make([]Event, 0, limit)}
+}
+
+// Record validates and stores an event.
+func (h *EventHub) Record(event Event) (Event, error) {
+	if event.NodeID == "" {
+		return Event{}, ErrEmptyEventNodeID
+	}
+	if event.Type == "" {
+		return Event{}, ErrEmptyEventType
+	}
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now().UTC()
+	}
+	if event.Data == nil {
+		event.Data = map[string]any{}
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.nextID++
+	event.ID = fmt.Sprintf("event-%d", h.nextID)
+	h.events = append(h.events, event)
+	if len(h.events) > h.limit {
+		h.events = h.events[len(h.events)-h.limit:]
+	}
+	return event, nil
+}
+
+// Query returns events matching the filter.
+func (h *EventHub) Query(filter EventFilter) []Event {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	events := make([]Event, 0, len(h.events))
+	for _, event := range h.events {
+		if filter.NodeID != "" && event.NodeID != filter.NodeID {
+			continue
+		}
+		if filter.Type != "" && event.Type != filter.Type {
+			continue
+		}
+		if !filter.Since.IsZero() && event.Timestamp.Before(filter.Since) {
+			continue
+		}
+		events = append(events, event)
+	}
+	return events
+}

--- a/pkg/fleet/events_test.go
+++ b/pkg/fleet/events_test.go
@@ -1,0 +1,67 @@
+package fleet
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEventHubStoresBoundedEventsAndFiltersQueries(t *testing.T) {
+	hub := NewEventHub(2)
+	start := time.Unix(100, 0).UTC()
+
+	if _, err := hub.Record(Event{
+		NodeID:    "node-1",
+		Type:      "temperature",
+		Data:      map[string]any{"temperature_c": 33.1},
+		Timestamp: start,
+	}); err != nil {
+		t.Fatalf("record first event: %v", err)
+	}
+	if _, err := hub.Record(Event{
+		NodeID:    "node-2",
+		Type:      "humidity",
+		Data:      map[string]any{"humidity_pct": 71.0},
+		Timestamp: start.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("record second event: %v", err)
+	}
+	if _, err := hub.Record(Event{
+		NodeID:    "node-1",
+		Type:      "temperature",
+		Data:      map[string]any{"temperature_c": 34.2},
+		Timestamp: start.Add(2 * time.Second),
+	}); err != nil {
+		t.Fatalf("record third event: %v", err)
+	}
+
+	all := hub.Query(EventFilter{})
+	if len(all) != 2 {
+		t.Fatalf("expected bounded buffer to retain 2 events, got %d", len(all))
+	}
+	if all[0].NodeID != "node-2" || all[1].NodeID != "node-1" {
+		t.Fatalf("expected oldest event to be evicted, got %#v", all)
+	}
+
+	filtered := hub.Query(EventFilter{
+		NodeID: "node-1",
+		Type:   "temperature",
+		Since:  start.Add(time.Second),
+	})
+	if len(filtered) != 1 {
+		t.Fatalf("expected one filtered event, got %d", len(filtered))
+	}
+	if filtered[0].Data["temperature_c"] != 34.2 {
+		t.Fatalf("expected latest temperature event, got %#v", filtered[0])
+	}
+}
+
+func TestEventHubRejectsInvalidEvents(t *testing.T) {
+	hub := NewEventHub(10)
+
+	if _, err := hub.Record(Event{Type: "temperature", Data: map[string]any{}}); err == nil {
+		t.Fatal("expected missing node id to be rejected")
+	}
+	if _, err := hub.Record(Event{NodeID: "node-1", Data: map[string]any{}}); err == nil {
+		t.Fatal("expected missing event type to be rejected")
+	}
+}

--- a/pkg/fleet/registry.go
+++ b/pkg/fleet/registry.go
@@ -8,14 +8,15 @@ import (
 
 // Node represents a registered edge agent.
 type Node struct {
-	ID           string            `json:"id"`
-	Name         string            `json:"name"`
-	Type         string            `json:"type"` // picclaw, nanoclaw, microclaw
-	Capabilities []string          `json:"capabilities"`
-	Location     string            `json:"location,omitempty"`
-	LastSeen     time.Time         `json:"last_seen"`
-	Status       string            `json:"status"` // online, offline, degraded
-	Metadata     map[string]string `json:"metadata,omitempty"`
+	ID           string             `json:"id"`
+	Name         string             `json:"name"`
+	Type         string             `json:"type"` // picclaw, nanoclaw, microclaw
+	Capabilities []string           `json:"capabilities"`
+	Location     string             `json:"location,omitempty"`
+	LastSeen     time.Time          `json:"last_seen"`
+	Status       string             `json:"status"` // online, offline, degraded
+	Metrics      map[string]float64 `json:"metrics,omitempty"`
+	Metadata     map[string]string  `json:"metadata,omitempty"`
 }
 
 // Registry manages registered edge nodes.
@@ -40,14 +41,34 @@ func (r *Registry) Register(node *Node) {
 
 // Heartbeat updates the last seen time for a node.
 func (r *Registry) Heartbeat(nodeID string) bool {
+	_, ok := r.UpdateHeartbeat(nodeID, "online", nil)
+	return ok
+}
+
+// UpdateHeartbeat updates liveness, status, and metrics for a node.
+func (r *Registry) UpdateHeartbeat(nodeID, status string, metrics map[string]float64) (*Node, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if n, ok := r.nodes[nodeID]; ok {
 		n.LastSeen = time.Now()
-		n.Status = "online"
-		return true
+		if status == "" {
+			status = "online"
+		}
+		n.Status = status
+		if metrics != nil {
+			n.Metrics = metrics
+		}
+		return n, true
 	}
-	return false
+	return nil, false
+}
+
+// Get returns a registered node by ID.
+func (r *Registry) Get(nodeID string) (*Node, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	node, ok := r.nodes[nodeID]
+	return node, ok
 }
 
 // List returns all registered nodes.
@@ -59,4 +80,31 @@ func (r *Registry) List() []*Node {
 		nodes = append(nodes, n)
 	}
 	return nodes
+}
+
+// ListByStatus returns nodes that match the given status.
+func (r *Registry) ListByStatus(status string) []*Node {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	nodes := make([]*Node, 0)
+	for _, n := range r.nodes {
+		if n.Status == status {
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
+}
+
+// MarkOffline marks nodes offline when their last heartbeat is too old.
+func (r *Registry) MarkOffline(timeout time.Duration, now time.Time) []*Node {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	offline := make([]*Node, 0)
+	for _, n := range r.nodes {
+		if n.Status != "offline" && now.Sub(n.LastSeen) >= timeout {
+			n.Status = "offline"
+			offline = append(offline, n)
+		}
+	}
+	return offline
 }

--- a/pkg/fleet/registry_test.go
+++ b/pkg/fleet/registry_test.go
@@ -1,0 +1,37 @@
+package fleet
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRegistryUpdatesHeartbeatMetricsAndMarksOffline(t *testing.T) {
+	registry := NewRegistry()
+	registry.Register(&Node{
+		ID:           "node-1",
+		Name:         "Rack A1",
+		Type:         "picclaw",
+		Capabilities: []string{"temperature", "relay"},
+	})
+
+	node, ok := registry.UpdateHeartbeat("node-1", "degraded", map[string]float64{"cpu_pct": 72.5})
+	if !ok {
+		t.Fatal("expected heartbeat to update existing node")
+	}
+	if node.Status != "degraded" {
+		t.Fatalf("expected degraded status, got %q", node.Status)
+	}
+	if node.Metrics["cpu_pct"] != 72.5 {
+		t.Fatalf("expected heartbeat metrics to be stored, got %#v", node.Metrics)
+	}
+
+	node.LastSeen = time.Now().Add(-5 * time.Minute)
+	offline := registry.MarkOffline(2*time.Minute, time.Now())
+
+	if len(offline) != 1 || offline[0].ID != "node-1" {
+		t.Fatalf("expected node-1 to be marked offline, got %#v", offline)
+	}
+	if node.Status != "offline" {
+		t.Fatalf("expected offline status, got %q", node.Status)
+	}
+}

--- a/pkg/fleet/server.go
+++ b/pkg/fleet/server.go
@@ -1,0 +1,218 @@
+package fleet
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Server exposes Fleet Manager HTTP endpoints.
+type Server struct {
+	registry *Registry
+	events   *EventHub
+	mux      *http.ServeMux
+}
+
+// NewServer creates a Fleet Manager HTTP server.
+func NewServer(registry *Registry, events *EventHub) *Server {
+	if registry == nil {
+		registry = NewRegistry()
+	}
+	if events == nil {
+		events = NewEventHub(1000)
+	}
+	server := &Server{
+		registry: registry,
+		events:   events,
+		mux:      http.NewServeMux(),
+	}
+	server.mux.HandleFunc("/fleet/register", server.handleRegister)
+	server.mux.HandleFunc("/fleet/heartbeat", server.handleHeartbeat)
+	server.mux.HandleFunc("/fleet/events", server.handleEvents)
+	server.mux.HandleFunc("/fleet/nodes/", server.handleNode)
+	server.mux.HandleFunc("/fleet/nodes", server.handleNodes)
+	return server
+}
+
+// ServeHTTP routes Fleet Manager API requests.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}
+
+type registerRequest struct {
+	NodeID       string            `json:"node_id"`
+	Name         string            `json:"name"`
+	Type         string            `json:"type"`
+	Capabilities []string          `json:"capabilities"`
+	Location     string            `json:"location"`
+	Metadata     map[string]string `json:"metadata"`
+}
+
+type heartbeatRequest struct {
+	NodeID  string             `json:"node_id"`
+	Status  string             `json:"status"`
+	Metrics map[string]float64 `json:"metrics"`
+}
+
+type heartbeatResponse struct {
+	OK   bool  `json:"ok"`
+	Node *Node `json:"node"`
+}
+
+type nodesResponse struct {
+	Nodes []*Node `json:"nodes"`
+}
+
+type eventsResponse struct {
+	Events []Event `json:"events"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+
+	var request registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON body"})
+		return
+	}
+	if request.NodeID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "node_id is required"})
+		return
+	}
+	node := &Node{
+		ID:           request.NodeID,
+		Name:         request.Name,
+		Type:         request.Type,
+		Capabilities: request.Capabilities,
+		Location:     request.Location,
+		Metadata:     request.Metadata,
+	}
+	s.registry.Register(node)
+	writeJSON(w, http.StatusCreated, node)
+}
+
+func (s *Server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+
+	var request heartbeatRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON body"})
+		return
+	}
+	if request.NodeID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "node_id is required"})
+		return
+	}
+	node, ok := s.registry.UpdateHeartbeat(request.NodeID, request.Status, request.Metrics)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "node not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, heartbeatResponse{OK: true, Node: node})
+}
+
+func (s *Server) handleNodes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	status := r.URL.Query().Get("status")
+	if status != "" {
+		writeJSON(w, http.StatusOK, nodesResponse{Nodes: s.registry.ListByStatus(status)})
+		return
+	}
+	writeJSON(w, http.StatusOK, nodesResponse{Nodes: s.registry.List()})
+}
+
+func (s *Server) handleNode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	nodeID := strings.TrimPrefix(r.URL.Path, "/fleet/nodes/")
+	if nodeID == "" || strings.Contains(nodeID, "/") {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "node not found"})
+		return
+	}
+	node, ok := s.registry.Get(nodeID)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "node not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, node)
+}
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handlePostEvent(w, r)
+	case http.MethodGet:
+		s.handleListEvents(w, r)
+	default:
+		w.Header().Set("Allow", http.MethodGet+", "+http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+	}
+}
+
+func (s *Server) handlePostEvent(w http.ResponseWriter, r *http.Request) {
+	var event Event
+	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid JSON body"})
+		return
+	}
+	if event.NodeID == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: ErrEmptyEventNodeID.Error()})
+		return
+	}
+	if event.Type == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: ErrEmptyEventType.Error()})
+		return
+	}
+	if _, ok := s.registry.Get(event.NodeID); !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "node not found"})
+		return
+	}
+	stored, err := s.events.Record(event)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusAccepted, stored)
+}
+
+func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
+	filter := EventFilter{
+		NodeID: r.URL.Query().Get("node_id"),
+		Type:   r.URL.Query().Get("type"),
+	}
+	if since := r.URL.Query().Get("since"); since != "" {
+		parsed, err := time.Parse(time.RFC3339, since)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid since timestamp"})
+			return
+		}
+		filter.Since = parsed
+	}
+	writeJSON(w, http.StatusOK, eventsResponse{Events: s.events.Query(filter)})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/pkg/fleet/server_test.go
+++ b/pkg/fleet/server_test.go
@@ -1,0 +1,127 @@
+package fleet
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestServerHandlesNodeLifecycleAndEvents(t *testing.T) {
+	server := NewServer(NewRegistry(), NewEventHub(10))
+
+	register := httptest.NewRequest(http.MethodPost, "/fleet/register", bytes.NewBufferString(`{
+		"node_id":"node-1",
+		"name":"Rack A1",
+		"type":"picclaw",
+		"capabilities":["temperature","relay"],
+		"location":"rack-a"
+	}`))
+	register.Header.Set("Content-Type", "application/json")
+	registerResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(registerResponse, register)
+
+	if registerResponse.Code != http.StatusCreated {
+		t.Fatalf("expected register status %d, got %d: %s", http.StatusCreated, registerResponse.Code, registerResponse.Body.String())
+	}
+
+	heartbeat := httptest.NewRequest(http.MethodPost, "/fleet/heartbeat", bytes.NewBufferString(`{
+		"node_id":"node-1",
+		"status":"online",
+		"metrics":{"cpu_pct":13.5,"queue_depth":1}
+	}`))
+	heartbeat.Header.Set("Content-Type", "application/json")
+	heartbeatResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(heartbeatResponse, heartbeat)
+
+	if heartbeatResponse.Code != http.StatusOK {
+		t.Fatalf("expected heartbeat status %d, got %d: %s", http.StatusOK, heartbeatResponse.Code, heartbeatResponse.Body.String())
+	}
+	var heartbeatBody struct {
+		OK   bool `json:"ok"`
+		Node Node `json:"node"`
+	}
+	if err := json.NewDecoder(heartbeatResponse.Body).Decode(&heartbeatBody); err != nil {
+		t.Fatalf("decode heartbeat response: %v", err)
+	}
+	if !heartbeatBody.OK || heartbeatBody.Node.Metrics["cpu_pct"] != 13.5 {
+		t.Fatalf("expected heartbeat metrics in response, got %#v", heartbeatBody)
+	}
+
+	event := httptest.NewRequest(http.MethodPost, "/fleet/events", bytes.NewBufferString(`{
+		"node_id":"node-1",
+		"type":"temperature_warning",
+		"data":{"temperature_c":38.4}
+	}`))
+	event.Header.Set("Content-Type", "application/json")
+	eventResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(eventResponse, event)
+
+	if eventResponse.Code != http.StatusAccepted {
+		t.Fatalf("expected event status %d, got %d: %s", http.StatusAccepted, eventResponse.Code, eventResponse.Body.String())
+	}
+
+	listNodes := httptest.NewRequest(http.MethodGet, "/fleet/nodes?status=online", nil)
+	nodesResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(nodesResponse, listNodes)
+
+	if nodesResponse.Code != http.StatusOK {
+		t.Fatalf("expected list nodes status %d, got %d: %s", http.StatusOK, nodesResponse.Code, nodesResponse.Body.String())
+	}
+	var nodesBody struct {
+		Nodes []Node `json:"nodes"`
+	}
+	if err := json.NewDecoder(nodesResponse.Body).Decode(&nodesBody); err != nil {
+		t.Fatalf("decode nodes response: %v", err)
+	}
+	if len(nodesBody.Nodes) != 1 || nodesBody.Nodes[0].ID != "node-1" {
+		t.Fatalf("expected node-1 in nodes response, got %#v", nodesBody.Nodes)
+	}
+
+	listEvents := httptest.NewRequest(http.MethodGet, "/fleet/events?node_id=node-1&type=temperature_warning", nil)
+	eventsResponse := httptest.NewRecorder()
+
+	server.ServeHTTP(eventsResponse, listEvents)
+
+	if eventsResponse.Code != http.StatusOK {
+		t.Fatalf("expected list events status %d, got %d: %s", http.StatusOK, eventsResponse.Code, eventsResponse.Body.String())
+	}
+	var eventsBody struct {
+		Events []Event `json:"events"`
+	}
+	if err := json.NewDecoder(eventsResponse.Body).Decode(&eventsBody); err != nil {
+		t.Fatalf("decode events response: %v", err)
+	}
+	if len(eventsBody.Events) != 1 || eventsBody.Events[0].Type != "temperature_warning" {
+		t.Fatalf("expected temperature warning event, got %#v", eventsBody.Events)
+	}
+}
+
+func TestServerRejectsHeartbeatForUnknownNode(t *testing.T) {
+	server := NewServer(NewRegistry(), NewEventHub(10))
+	request := httptest.NewRequest(http.MethodPost, "/fleet/heartbeat", bytes.NewBufferString(`{"node_id":"missing"}`))
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusNotFound, response.Code, response.Body.String())
+	}
+}
+
+func TestServerRejectsInvalidEvents(t *testing.T) {
+	server := NewServer(NewRegistry(), NewEventHub(10))
+	request := httptest.NewRequest(http.MethodPost, "/fleet/events", bytes.NewBufferString(`{"type":"temperature","data":{}}`))
+	response := httptest.NewRecorder()
+
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, response.Code, response.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- adds a Fleet Manager HTTP server for node registration, heartbeat updates, node listing/detail lookup, event ingestion, and event query filters
- extends the in-memory registry with heartbeat metrics, status filters, lookup, and timeout-based offline marking
- adds a bounded in-memory event hub with validation, normalization, and node/type/since filters
- starts the HTTP server from `cmd/fleet` and documents the implemented endpoints

Closes #2.
Closes #3.

## Verification
- TDD red check: `go test ./...` failed first on missing `NewEventHub`, `Event`, `EventFilter`, `UpdateHeartbeat`, and `NewServer`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- Smoke test with built binary on `PORT=18081`: `POST /fleet/register` -> 201, `POST /fleet/heartbeat` -> 200, invalid event -> 400, `POST /fleet/events` -> 202, `GET /fleet/events?node_id=node-smoke&type=temperature` -> 200