### PR TITLE
feat: add fleet manager dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Clawland Fleet is the **nervous system** connecting cloud and edge. It provides 
 - **Health Dashboard** — Real-time monitoring with alerting
 - **OTA Orchestrator** — Rolling firmware/skill updates with rollback
 
+### Dashboard Preview
+
+The first Fleet Manager dashboard lives in `web/dashboard/`. It is a
+dependency-free static UI for node status, alert aggregation, command dispatch,
+and geolocated node monitoring.
+
+```bash
+cd web/dashboard
+python3 -m http.server 8088
+```
+
+Open `http://localhost:8088` to preview the dashboard with sample fleet data.
+
 ### Edge API Server (runs on PicClaw)
 - **REST/gRPC API** — Receive commands from cloud
 - **Local Task Queue** — Buffer commands during offline periods

--- a/web/dashboard/README.md
+++ b/web/dashboard/README.md
@@ -1,0 +1,45 @@
+# Fleet Manager Dashboard
+
+Static dashboard for the Clawland Fleet Manager bounty. It is dependency-free
+vanilla HTML/CSS/JavaScript so it can be served by the existing Go binary, a CDN,
+or any local static server.
+
+## Features
+
+- Real-time style node status board with online, degraded, and offline nodes.
+- Alert aggregation by severity and source node.
+- Command dispatch panel with safe command templates.
+- Map view for geolocated nodes using CSS positioning and latitude/longitude.
+- Mock SSE refresh loop for local demos; replace with `/api/events` when the
+  Fleet Manager exposes a live stream.
+- Responsive layout for laptop and tablet operations rooms.
+
+## Local Preview
+
+```bash
+cd web/dashboard
+python3 -m http.server 8088
+```
+
+Open `http://localhost:8088`.
+
+## Integration Points
+
+The dashboard expects the following JSON shape from a future Fleet Manager API:
+
+- `GET /api/fleet/status` -> full snapshot matching `fixtures/fleet-state.json`
+- `GET /api/fleet/events` -> Server-Sent Events stream with node or alert deltas
+- `POST /api/fleet/commands` -> command dispatch body:
+
+```json
+{
+  "node_id": "pond-guardian-01",
+  "command": "skill.restart",
+  "payload": {
+    "skill": "aquaculture-monitoring"
+  }
+}
+```
+
+The local demo keeps command history in browser memory and does not contact a
+backend.

--- a/web/dashboard/app.js
+++ b/web/dashboard/app.js
@@ -1,0 +1,229 @@
+const state = {
+  snapshot: null,
+  filter: 'all',
+  commands: []
+};
+
+const elements = {
+  lastUpdated: document.querySelector('#lastUpdated'),
+  totalNodes: document.querySelector('#totalNodes'),
+  onlineNodes: document.querySelector('#onlineNodes'),
+  degradedNodes: document.querySelector('#degradedNodes'),
+  openAlerts: document.querySelector('#openAlerts'),
+  criticalCount: document.querySelector('#criticalCount'),
+  queuedCount: document.querySelector('#queuedCount'),
+  nodeList: document.querySelector('#nodeList'),
+  alertList: document.querySelector('#alertList'),
+  commandList: document.querySelector('#commandList'),
+  commandNode: document.querySelector('#commandNode'),
+  commandType: document.querySelector('#commandType'),
+  commandPayload: document.querySelector('#commandPayload'),
+  commandForm: document.querySelector('#commandForm'),
+  map: document.querySelector('#map'),
+  refreshButton: document.querySelector('#refreshButton'),
+  filterButtons: document.querySelectorAll('[data-filter]')
+};
+
+async function loadSnapshot() {
+  const response = await fetch('./fixtures/fleet-state.json', { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Unable to load fleet snapshot: ${response.status}`);
+  }
+  const snapshot = await response.json();
+  state.snapshot = simulateRealtime(snapshot);
+  state.commands = [...state.snapshot.commands, ...state.commands.filter((command) => command.local)];
+  render();
+}
+
+function simulateRealtime(snapshot) {
+  const now = new Date();
+  const copy = structuredClone(snapshot);
+  copy.generated_at = now.toISOString();
+  copy.nodes = copy.nodes.map((node, index) => {
+    if (node.status === 'offline') return node;
+    return {
+      ...node,
+      last_seen: new Date(now.getTime() - index * 13000).toISOString(),
+      metrics: {
+        ...node.metrics,
+        latency_ms: Math.max(80, Math.round((node.metrics.latency_ms || 220) * (0.9 + Math.random() * 0.2))),
+        cpu_percent: Math.min(96, Math.max(4, Math.round(node.metrics.cpu_percent + Math.random() * 8 - 4)))
+      }
+    };
+  });
+  return copy;
+}
+
+function render() {
+  if (!state.snapshot) return;
+  const { nodes, alerts } = state.snapshot;
+  const openAlerts = alerts.filter((alert) => !alert.acknowledged);
+  const criticalAlerts = openAlerts.filter((alert) => alert.severity === 'critical');
+
+  elements.lastUpdated.textContent = `Updated ${formatTime(state.snapshot.generated_at)}`;
+  elements.totalNodes.textContent = String(nodes.length);
+  elements.onlineNodes.textContent = String(nodes.filter((node) => node.status === 'online').length);
+  elements.degradedNodes.textContent = String(nodes.filter((node) => node.status === 'degraded').length);
+  elements.openAlerts.textContent = String(openAlerts.length);
+  elements.criticalCount.textContent = `${criticalAlerts.length} critical`;
+  elements.queuedCount.textContent = `${state.commands.filter((command) => command.status === 'queued').length} queued`;
+
+  renderNodes(nodes);
+  renderAlerts(alerts);
+  renderCommands(state.commands);
+  renderNodeOptions(nodes);
+  renderMap(nodes);
+}
+
+function renderNodes(nodes) {
+  const filtered = state.filter === 'all' ? nodes : nodes.filter((node) => node.status === state.filter);
+  elements.nodeList.innerHTML = filtered.map((node) => `
+    <article class="node-card">
+      <div>
+        <div class="node-title">
+          <span class="status-dot status-${escapeHtml(node.status)}"></span>
+          <strong>${escapeHtml(node.name)}</strong>
+        </div>
+        <div class="node-meta">
+          <span>${escapeHtml(node.id)}</span>
+          <span>${escapeHtml(node.type)}</span>
+          <span>${escapeHtml(node.location)}</span>
+          <span>Seen ${formatTime(node.last_seen)}</span>
+        </div>
+        <div class="chips" aria-label="Capabilities">
+          ${node.capabilities.map((capability) => `<span class="chip">${escapeHtml(capability)}</span>`).join('')}
+        </div>
+      </div>
+      <div class="metric-grid">
+        <span><strong>${node.metrics.cpu_percent}%</strong>CPU</span>
+        <span><strong>${node.metrics.memory_mb} MB</strong>Memory</span>
+        <span><strong>${node.metrics.battery_percent}%</strong>Battery</span>
+        <span><strong>${node.metrics.latency_ms ?? 'n/a'} ms</strong>Latency</span>
+      </div>
+    </article>
+  `).join('');
+}
+
+function renderAlerts(alerts) {
+  elements.alertList.innerHTML = alerts.map((alert) => `
+    <article class="alert-item alert-${escapeHtml(alert.severity)}">
+      <strong>${escapeHtml(alert.title)}</strong>
+      <p>${escapeHtml(alert.message)}</p>
+      <div class="node-meta">
+        <span>${escapeHtml(alert.node_id)}</span>
+        <span>${escapeHtml(alert.severity)}</span>
+        <span>${formatTime(alert.timestamp)}</span>
+        <span>${alert.acknowledged ? 'acknowledged' : 'open'}</span>
+      </div>
+    </article>
+  `).join('');
+}
+
+function renderCommands(commands) {
+  elements.commandList.innerHTML = commands.map((command) => `
+    <article class="command-item">
+      <strong>${escapeHtml(command.command)}</strong>
+      <div class="node-meta">
+        <span>${escapeHtml(command.node_id)}</span>
+        <span>${escapeHtml(command.status)}</span>
+        <span>${formatTime(command.created_at)}</span>
+      </div>
+    </article>
+  `).join('');
+}
+
+function renderNodeOptions(nodes) {
+  const selected = elements.commandNode.value;
+  elements.commandNode.innerHTML = nodes.map((node) => `
+    <option value="${escapeHtml(node.id)}">${escapeHtml(node.name)} (${escapeHtml(node.status)})</option>
+  `).join('');
+  if (nodes.some((node) => node.id === selected)) {
+    elements.commandNode.value = selected;
+  }
+}
+
+function renderMap(nodes) {
+  const bounds = nodes.reduce((acc, node) => ({
+    minLat: Math.min(acc.minLat, node.latitude),
+    maxLat: Math.max(acc.maxLat, node.latitude),
+    minLon: Math.min(acc.minLon, node.longitude),
+    maxLon: Math.max(acc.maxLon, node.longitude)
+  }), { minLat: 90, maxLat: -90, minLon: 180, maxLon: -180 });
+
+  elements.map.innerHTML = nodes.map((node) => {
+    const x = scale(node.longitude, bounds.minLon, bounds.maxLon, 12, 88);
+    const y = scale(node.latitude, bounds.minLat, bounds.maxLat, 84, 16);
+    return `
+      <div class="map-node" data-status="${escapeHtml(node.status)}" style="left:${x}%;top:${y}%">
+        <strong>${escapeHtml(node.name)}</strong>
+        <div class="node-meta">${escapeHtml(node.location)}</div>
+      </div>
+    `;
+  }).join('');
+}
+
+function scale(value, min, max, outMin, outMax) {
+  if (min === max) return (outMin + outMax) / 2;
+  return outMin + ((value - min) / (max - min)) * (outMax - outMin);
+}
+
+function formatTime(value) {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).format(new Date(value));
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+elements.filterButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    state.filter = button.dataset.filter;
+    elements.filterButtons.forEach((item) => item.classList.toggle('is-active', item === button));
+    render();
+  });
+});
+
+elements.refreshButton.addEventListener('click', () => {
+  loadSnapshot().catch((error) => {
+    elements.lastUpdated.textContent = error.message;
+  });
+});
+
+elements.commandForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  let payload;
+  try {
+    payload = JSON.parse(elements.commandPayload.value);
+  } catch {
+    elements.commandPayload.focus();
+    return;
+  }
+  state.commands.unshift({
+    id: `local-${Date.now()}`,
+    node_id: elements.commandNode.value,
+    command: elements.commandType.value,
+    payload,
+    status: 'queued',
+    local: true,
+    created_at: new Date().toISOString()
+  });
+  renderCommands(state.commands);
+  elements.queuedCount.textContent = `${state.commands.filter((command) => command.status === 'queued').length} queued`;
+});
+
+loadSnapshot().catch((error) => {
+  elements.lastUpdated.textContent = error.message;
+});
+
+setInterval(() => {
+  loadSnapshot().catch(() => {});
+}, 30000);

--- a/web/dashboard/fixtures/fleet-state.json
+++ b/web/dashboard/fixtures/fleet-state.json
@@ -1,0 +1,118 @@
+{
+  "generated_at": "2026-05-21T15:45:00Z",
+  "nodes": [
+    {
+      "id": "pond-guardian-01",
+      "name": "Pond Guardian 01",
+      "type": "picclaw",
+      "status": "online",
+      "location": "Guangdong Pond A",
+      "latitude": 23.1291,
+      "longitude": 113.2644,
+      "last_seen": "2026-05-21T15:44:48Z",
+      "capabilities": ["aquaculture-monitoring", "relay-control", "sensor.water_quality"],
+      "metrics": {
+        "cpu_percent": 34,
+        "memory_mb": 6.4,
+        "battery_percent": 88,
+        "latency_ms": 142
+      }
+    },
+    {
+      "id": "cold-chain-truck-07",
+      "name": "Cold Chain Truck 07",
+      "type": "picclaw",
+      "status": "degraded",
+      "location": "Shanghai Route B",
+      "latitude": 31.2304,
+      "longitude": 121.4737,
+      "last_seen": "2026-05-21T15:42:10Z",
+      "capabilities": ["cold-chain-compliance", "gps", "temperature"],
+      "metrics": {
+        "cpu_percent": 51,
+        "memory_mb": 7.2,
+        "battery_percent": 41,
+        "latency_ms": 640
+      }
+    },
+    {
+      "id": "greenhouse-edge-03",
+      "name": "Greenhouse Edge 03",
+      "type": "nanoclaw",
+      "status": "online",
+      "location": "Chengdu Greenhouse",
+      "latitude": 30.5728,
+      "longitude": 104.0668,
+      "last_seen": "2026-05-21T15:44:59Z",
+      "capabilities": ["greenhouse-climate", "irrigation-control", "camera"],
+      "metrics": {
+        "cpu_percent": 27,
+        "memory_mb": 128.5,
+        "battery_percent": 100,
+        "latency_ms": 210
+      }
+    },
+    {
+      "id": "warehouse-guard-02",
+      "name": "Warehouse Guard 02",
+      "type": "microclaw",
+      "status": "offline",
+      "location": "Suzhou Warehouse",
+      "latitude": 31.2989,
+      "longitude": 120.5853,
+      "last_seen": "2026-05-21T14:58:03Z",
+      "capabilities": ["motion-detect", "door-sensor"],
+      "metrics": {
+        "cpu_percent": 0,
+        "memory_mb": 0,
+        "battery_percent": 16,
+        "latency_ms": null
+      }
+    }
+  ],
+  "alerts": [
+    {
+      "id": "alert-001",
+      "node_id": "cold-chain-truck-07",
+      "severity": "critical",
+      "title": "Temperature excursion",
+      "message": "Cargo bay has been above 8 C for 18 minutes.",
+      "timestamp": "2026-05-21T15:37:12Z",
+      "acknowledged": false
+    },
+    {
+      "id": "alert-002",
+      "node_id": "warehouse-guard-02",
+      "severity": "warning",
+      "title": "Node offline",
+      "message": "No heartbeat received for 47 minutes.",
+      "timestamp": "2026-05-21T15:45:00Z",
+      "acknowledged": false
+    },
+    {
+      "id": "alert-003",
+      "node_id": "pond-guardian-01",
+      "severity": "info",
+      "title": "Preventive aeration complete",
+      "message": "Dissolved oxygen recovered to 5.6 mg/L.",
+      "timestamp": "2026-05-21T15:22:18Z",
+      "acknowledged": true
+    }
+  ],
+  "commands": [
+    {
+      "id": "cmd-101",
+      "node_id": "pond-guardian-01",
+      "command": "skill.restart",
+      "status": "completed",
+      "created_at": "2026-05-21T14:15:00Z"
+    },
+    {
+      "id": "cmd-102",
+      "node_id": "cold-chain-truck-07",
+      "command": "sensor.recalibrate",
+      "status": "queued",
+      "created_at": "2026-05-21T15:39:42Z"
+    }
+  ]
+}

--- a/web/dashboard/index.html
+++ b/web/dashboard/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Clawland Fleet Dashboard</title>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Clawland Fleet</p>
+        <h1>Fleet Manager Dashboard</h1>
+      </div>
+      <div class="topbar__meta">
+        <span id="lastUpdated">Loading...</span>
+        <button id="refreshButton" type="button">Refresh</button>
+      </div>
+    </header>
+
+    <main class="dashboard">
+      <section class="metrics" aria-label="Fleet summary">
+        <article>
+          <span>Total Nodes</span>
+          <strong id="totalNodes">0</strong>
+        </article>
+        <article>
+          <span>Online</span>
+          <strong id="onlineNodes">0</strong>
+        </article>
+        <article>
+          <span>Degraded</span>
+          <strong id="degradedNodes">0</strong>
+        </article>
+        <article>
+          <span>Open Alerts</span>
+          <strong id="openAlerts">0</strong>
+        </article>
+      </section>
+
+      <section class="layout">
+        <div class="panel panel--wide">
+          <div class="panel__header">
+            <h2>Node Status</h2>
+            <div class="segmented" role="tablist" aria-label="Node filter">
+              <button class="is-active" data-filter="all" type="button">All</button>
+              <button data-filter="online" type="button">Online</button>
+              <button data-filter="degraded" type="button">Degraded</button>
+              <button data-filter="offline" type="button">Offline</button>
+            </div>
+          </div>
+          <div id="nodeList" class="node-list" aria-live="polite"></div>
+        </div>
+
+        <div class="panel">
+          <div class="panel__header">
+            <h2>Alerts</h2>
+            <span id="criticalCount" class="badge badge--critical">0 critical</span>
+          </div>
+          <div id="alertList" class="alert-list" aria-live="polite"></div>
+        </div>
+      </section>
+
+      <section class="layout">
+        <div class="panel panel--wide">
+          <div class="panel__header">
+            <h2>Map View</h2>
+            <span class="hint">Geolocated edge nodes</span>
+          </div>
+          <div id="map" class="map" aria-label="Fleet map"></div>
+        </div>
+
+        <div class="panel">
+          <div class="panel__header">
+            <h2>Dispatch Command</h2>
+            <span class="hint">Queued locally in demo mode</span>
+          </div>
+          <form id="commandForm" class="command-form">
+            <label>
+              Node
+              <select id="commandNode" name="node"></select>
+            </label>
+            <label>
+              Command
+              <select id="commandType" name="command">
+                <option value="skill.restart">Restart skill</option>
+                <option value="sensor.recalibrate">Recalibrate sensor</option>
+                <option value="config.sync">Sync configuration</option>
+                <option value="ota.check">Check OTA update</option>
+              </select>
+            </label>
+            <label>
+              Payload
+              <textarea id="commandPayload" name="payload" rows="5">{"skill":"aquaculture-monitoring"}</textarea>
+            </label>
+            <button type="submit">Queue Command</button>
+          </form>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel__header">
+          <h2>Command Queue</h2>
+          <span id="queuedCount" class="hint">0 queued</span>
+        </div>
+        <div id="commandList" class="command-list"></div>
+      </section>
+    </main>
+
+    <script src="./app.js" defer></script>
+  </body>
+</html>

--- a/web/dashboard/styles.css
+++ b/web/dashboard/styles.css
@@ -1,0 +1,389 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f8fb;
+  --surface: #ffffff;
+  --surface-strong: #f0f4f8;
+  --text: #18202f;
+  --muted: #627084;
+  --line: #d8e0ea;
+  --green: #1f8a58;
+  --amber: #b36b00;
+  --red: #c9372c;
+  --blue: #2563eb;
+  --shadow: 0 12px 32px rgba(24, 32, 47, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button,
+select,
+textarea {
+  font: inherit;
+}
+
+.topbar {
+  align-items: center;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  padding: 20px 28px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.eyebrow {
+  color: var(--blue);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: 24px;
+  margin-bottom: 0;
+}
+
+h2 {
+  font-size: 16px;
+  margin-bottom: 0;
+}
+
+.topbar__meta {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  gap: 12px;
+  white-space: nowrap;
+}
+
+button {
+  background: var(--text);
+  border: 0;
+  border-radius: 8px;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 9px 12px;
+}
+
+button:hover {
+  filter: brightness(1.08);
+}
+
+.dashboard {
+  display: grid;
+  gap: 20px;
+  padding: 24px 28px 36px;
+}
+
+.metrics {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.metrics article,
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.metrics article {
+  padding: 18px;
+}
+
+.metrics span,
+.hint {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.metrics strong {
+  display: block;
+  font-size: 32px;
+  margin-top: 8px;
+}
+
+.layout {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(0, 1.65fr) minmax(320px, 0.85fr);
+}
+
+.panel {
+  min-width: 0;
+  padding: 18px;
+}
+
+.panel--wide {
+  min-height: 320px;
+}
+
+.panel__header {
+  align-items: center;
+  display: flex;
+  gap: 14px;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.segmented {
+  background: var(--surface-strong);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: inline-flex;
+  padding: 3px;
+}
+
+.segmented button {
+  background: transparent;
+  color: var(--muted);
+  padding: 7px 10px;
+}
+
+.segmented button.is-active {
+  background: var(--surface);
+  box-shadow: 0 2px 8px rgba(24, 32, 47, 0.12);
+  color: var(--text);
+}
+
+.node-list {
+  display: grid;
+  gap: 12px;
+}
+
+.node-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(220px, 1.2fr) minmax(240px, 1fr);
+  padding: 14px;
+}
+
+.node-title {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.status-dot {
+  border-radius: 50%;
+  height: 10px;
+  width: 10px;
+}
+
+.status-online {
+  background: var(--green);
+}
+
+.status-degraded {
+  background: var(--amber);
+}
+
+.status-offline {
+  background: var(--red);
+}
+
+.node-meta,
+.chips {
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 13px;
+  gap: 8px;
+}
+
+.chip {
+  background: var(--surface-strong);
+  border-radius: 999px;
+  padding: 4px 8px;
+}
+
+.metric-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.metric-grid span {
+  background: var(--surface-strong);
+  border-radius: 8px;
+  color: var(--muted);
+  padding: 8px;
+}
+
+.metric-grid strong {
+  color: var(--text);
+  display: block;
+}
+
+.alert-list,
+.command-list {
+  display: grid;
+  gap: 10px;
+}
+
+.alert-item,
+.command-item {
+  border: 1px solid var(--line);
+  border-left-width: 4px;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.alert-critical {
+  border-left-color: var(--red);
+}
+
+.alert-warning {
+  border-left-color: var(--amber);
+}
+
+.alert-info {
+  border-left-color: var(--blue);
+}
+
+.badge {
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 5px 8px;
+}
+
+.badge--critical {
+  background: #fee4e2;
+  color: var(--red);
+}
+
+.map {
+  aspect-ratio: 16 / 9;
+  background:
+    linear-gradient(90deg, rgba(37, 99, 235, 0.08) 1px, transparent 1px),
+    linear-gradient(rgba(37, 99, 235, 0.08) 1px, transparent 1px),
+    #edf5ff;
+  background-size: 44px 44px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  min-height: 280px;
+  overflow: hidden;
+  position: relative;
+}
+
+.map-node {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  min-width: 150px;
+  padding: 8px;
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+
+.map-node::before {
+  border-radius: 50%;
+  content: "";
+  display: inline-block;
+  height: 8px;
+  margin-right: 6px;
+  width: 8px;
+}
+
+.map-node[data-status="online"]::before {
+  background: var(--green);
+}
+
+.map-node[data-status="degraded"]::before {
+  background: var(--amber);
+}
+
+.map-node[data-status="offline"]::before {
+  background: var(--red);
+}
+
+.command-form {
+  display: grid;
+  gap: 12px;
+}
+
+label {
+  color: var(--muted);
+  display: grid;
+  font-size: 13px;
+  font-weight: 700;
+  gap: 6px;
+}
+
+select,
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 10px;
+  width: 100%;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.command-item {
+  border-left-color: var(--blue);
+}
+
+@media (max-width: 980px) {
+  .metrics,
+  .layout,
+  .node-card {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard,
+  .topbar {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .panel__header,
+  .topbar__meta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .segmented {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Adds a dependency-free Fleet Manager dashboard for the Clawland bounty board Fleet Manager Dashboard task.

Includes:
- Real-time style node status board with online/degraded/offline filters
- Alert aggregation with critical/open state
- Command dispatch panel with safe local queue behavior
- Geolocated map view for edge nodes
- Sample fleet snapshot fixture
- Dashboard README with API integration points
- Root README preview instructions

Validation run locally:
- node --check web/dashboard/app.js
- python3 -m json.tool web/dashboard/fixtures/fleet-state.json
- go test ./...
- git diff --check
- Chrome headless screenshot render against python3 static server