### PR TITLE
feat: add fleet manager dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Clawland Fleet is the **nervous system** connecting cloud and edge. It provides 
 - **Batch Upload** — Compress and send sensor data on schedule
 - **Offline Buffer** — Store-and-forward when connectivity is lost
 
+## Fleet Dashboard
+
+The repository includes a dependency-free web dashboard at [`web/dashboard`](web/dashboard/README.md). It provides a node status board, alert aggregation, command dispatch controls, and a geolocated fleet map backed by a sample fleet snapshot.
+
+Preview it locally from the repository root:
+
+```sh
+python3 -m http.server 8088 -d web/dashboard
+```
+
+Then open `http://127.0.0.1:8088`.
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ The repository includes a dependency-free web dashboard at [`web/dashboard`](web
 Preview it locally from the repository root:
 
 ```sh
+go run ./cmd/fleet
+```
+
+Then open `http://127.0.0.1:8080`. The server exposes dashboard data at `GET /fleet/dashboard/state` and queues dashboard commands through `POST /fleet/command`.
+
+For a static-only preview:
+
+```sh
 python3 -m http.server 8088 -d web/dashboard
 ```
 

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -6,7 +6,10 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+
+	"github.com/Clawland-AI/clawland-fleet/pkg/fleet"
 )
 
 const version = "0.1.0"
@@ -21,5 +24,13 @@ func main() {
 	fmt.Printf("   Cloud-Edge orchestration starting on :%s...\n", port)
 	fmt.Println("   Waiting for edge agent registrations...")
 
+	dashboard := fleet.NewDemoDashboardService()
+	mux := http.NewServeMux()
+	mux.Handle("/fleet/", dashboard.Handler())
+	mux.Handle("/", http.FileServer(http.Dir("web/dashboard")))
+
 	log.Printf("Fleet Manager listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/pkg/fleet/dashboard.go
+++ b/pkg/fleet/dashboard.go
@@ -1,0 +1,294 @@
+package fleet
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GeoLocation describes where a fleet node appears on the dashboard map.
+type GeoLocation struct {
+	Name string  `json:"name"`
+	Lat  float64 `json:"lat"`
+	Lng  float64 `json:"lng"`
+	MapX int     `json:"map_x"`
+	MapY int     `json:"map_y"`
+}
+
+// NodeMetrics contains the small health snapshot shown in the dashboard.
+type NodeMetrics struct {
+	Battery     int     `json:"battery"`
+	Temperature float64 `json:"temperature_c"`
+	SignalDBM   int     `json:"signal_dbm"`
+}
+
+// DashboardNode is the JSON shape consumed by the web dashboard.
+type DashboardNode struct {
+	ID              string      `json:"id"`
+	Name            string      `json:"name"`
+	Type            string      `json:"type"`
+	Status          string      `json:"status"`
+	PendingCommands int         `json:"pending_commands"`
+	Capabilities    []string    `json:"capabilities"`
+	Location        GeoLocation `json:"location"`
+	Metrics         NodeMetrics `json:"metrics"`
+	LastSeen        time.Time   `json:"last_seen"`
+}
+
+// Alert represents an open Fleet Manager incident.
+type Alert struct {
+	ID        string    `json:"id"`
+	NodeID    string    `json:"node_id"`
+	Severity  string    `json:"severity"`
+	Title     string    `json:"title"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Command tracks a cloud-to-edge command queued from the dashboard.
+type Command struct {
+	ID        string          `json:"id"`
+	NodeID    string          `json:"node_id"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	Status    string          `json:"status"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+// DashboardState is returned by GET /fleet/dashboard/state.
+type DashboardState struct {
+	GeneratedAt time.Time       `json:"generated_at"`
+	Nodes       []DashboardNode `json:"nodes"`
+	Alerts      []Alert         `json:"alerts"`
+	Commands    []Command       `json:"commands"`
+}
+
+// DashboardService stores the in-memory data needed by the dashboard preview.
+type DashboardService struct {
+	mu       sync.RWMutex
+	nodes    map[string]DashboardNode
+	alerts   []Alert
+	commands []Command
+	now      func() time.Time
+}
+
+// NewDashboardService creates an empty dashboard service.
+func NewDashboardService() *DashboardService {
+	return &DashboardService{
+		nodes: make(map[string]DashboardNode),
+		now:   time.Now,
+	}
+}
+
+// NewDemoDashboardService returns a service seeded with realistic sample data.
+func NewDemoDashboardService() *DashboardService {
+	service := NewDashboardService()
+	now := time.Now().UTC()
+	for _, node := range []DashboardNode{
+		{
+			ID:              "pond-a-picoclaw",
+			Name:            "Pond A Gateway",
+			Type:            "picclaw",
+			Status:          "online",
+			Capabilities:    []string{"aquaculture-monitoring", "mqtt", "edge-api"},
+			Location:        GeoLocation{Name: "North pond", Lat: 37.781, Lng: -122.404, MapX: 32, MapY: 48},
+			Metrics:         NodeMetrics{Battery: 92, Temperature: 24.1, SignalDBM: -54},
+			LastSeen:        now.Add(-22 * time.Second),
+			PendingCommands: 0,
+		},
+		{
+			ID:              "greenhouse-3-nanoclaw",
+			Name:            "Greenhouse 3",
+			Type:            "nanoclaw",
+			Status:          "degraded",
+			Capabilities:    []string{"greenhouse", "relay-control", "camera"},
+			Location:        GeoLocation{Name: "West greenhouse", Lat: 37.786, Lng: -122.411, MapX: 58, MapY: 36},
+			Metrics:         NodeMetrics{Battery: 41, Temperature: 31.6, SignalDBM: -82},
+			LastSeen:        now.Add(-2 * time.Minute),
+			PendingCommands: 2,
+		},
+		{
+			ID:              "cold-chain-van-12",
+			Name:            "Van 12",
+			Type:            "picclaw",
+			Status:          "online",
+			Capabilities:    []string{"cold-chain", "gps", "audit-log"},
+			Location:        GeoLocation{Name: "Downtown route", Lat: 37.774, Lng: -122.419, MapX: 44, MapY: 66},
+			Metrics:         NodeMetrics{Battery: 77, Temperature: 3.8, SignalDBM: -63},
+			LastSeen:        now.Add(-47 * time.Second),
+			PendingCommands: 1,
+		},
+		{
+			ID:              "warehouse-door-2",
+			Name:            "Warehouse Door 2",
+			Type:            "microclaw",
+			Status:          "offline",
+			Capabilities:    []string{"door-sensor", "pir"},
+			Location:        GeoLocation{Name: "Loading dock", Lat: 37.769, Lng: -122.398, MapX: 72, MapY: 55},
+			Metrics:         NodeMetrics{Battery: 12, Temperature: 18.4, SignalDBM: -96},
+			LastSeen:        now.Add(-12 * time.Minute),
+			PendingCommands: 0,
+		},
+	} {
+		service.UpsertNode(node)
+	}
+	service.ReplaceAlerts([]Alert{
+		{ID: "alert-001", NodeID: "warehouse-door-2", Severity: "critical", Title: "Node missed three heartbeats", CreatedAt: now.Add(-12 * time.Minute)},
+		{ID: "alert-002", NodeID: "greenhouse-3-nanoclaw", Severity: "warning", Title: "Signal quality below deployment threshold", CreatedAt: now.Add(-6 * time.Minute)},
+		{ID: "alert-003", NodeID: "cold-chain-van-12", Severity: "info", Title: "Firmware update waiting for maintenance window", CreatedAt: now.Add(-98 * time.Minute)},
+	})
+	return service
+}
+
+// UpsertNode adds or replaces a node snapshot.
+func (s *DashboardService) UpsertNode(node DashboardNode) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodes[node.ID] = node
+}
+
+// ReplaceAlerts swaps the currently open alert list.
+func (s *DashboardService) ReplaceAlerts(alerts []Alert) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.alerts = append([]Alert(nil), alerts...)
+}
+
+// State returns a deterministic dashboard snapshot.
+func (s *DashboardService) State() DashboardState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	nodes := make([]DashboardNode, 0, len(s.nodes))
+	for _, node := range s.nodes {
+		nodes = append(nodes, node)
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].ID < nodes[j].ID
+	})
+
+	alerts := append([]Alert(nil), s.alerts...)
+	sort.Slice(alerts, func(i, j int) bool {
+		return alerts[i].CreatedAt.After(alerts[j].CreatedAt)
+	})
+
+	commands := append([]Command(nil), s.commands...)
+	sort.Slice(commands, func(i, j int) bool {
+		return commands[i].CreatedAt.After(commands[j].CreatedAt)
+	})
+
+	return DashboardState{
+		GeneratedAt: s.now().UTC(),
+		Nodes:       nodes,
+		Alerts:      alerts,
+		Commands:    commands,
+	}
+}
+
+// QueueCommand records a command for delivery to an edge node.
+func (s *DashboardService) QueueCommand(nodeID, commandType string, payload json.RawMessage) (Command, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.nodes[nodeID]; !ok {
+		return Command{}, false
+	}
+
+	now := s.now().UTC()
+	command := Command{
+		ID:        "cmd-" + now.Format("20060102150405.000000000"),
+		NodeID:    nodeID,
+		Type:      commandType,
+		Payload:   payload,
+		Status:    "pending",
+		CreatedAt: now,
+	}
+	s.commands = append(s.commands, command)
+	node := s.nodes[nodeID]
+	node.PendingCommands++
+	s.nodes[nodeID] = node
+	return command, true
+}
+
+// Handler returns the API routes used by the dashboard.
+func (s *DashboardService) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fleet/dashboard/state", s.handleState)
+	mux.HandleFunc("/fleet/nodes", s.handleNodes)
+	mux.HandleFunc("/fleet/alerts", s.handleAlerts)
+	mux.HandleFunc("/fleet/command", s.handleCommand)
+	return mux
+}
+
+func (s *DashboardService) handleState(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.State())
+}
+
+func (s *DashboardService) handleNodes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.State().Nodes)
+}
+
+func (s *DashboardService) handleAlerts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.State().Alerts)
+}
+
+func (s *DashboardService) handleCommand(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+		return
+	}
+
+	var request struct {
+		NodeID  string          `json:"node_id"`
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload"`
+	}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid command payload")
+		return
+	}
+
+	request.NodeID = strings.TrimSpace(request.NodeID)
+	request.Type = strings.TrimSpace(request.Type)
+	if request.NodeID == "" || request.Type == "" {
+		writeError(w, http.StatusBadRequest, "node_id and type are required")
+		return
+	}
+
+	command, ok := s.QueueCommand(request.NodeID, request.Type, request.Payload)
+	if !ok {
+		writeError(w, http.StatusNotFound, "node not found")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, command)
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+}

--- a/pkg/fleet/dashboard_test.go
+++ b/pkg/fleet/dashboard_test.go
@@ -1,0 +1,80 @@
+package fleet
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestDashboardStateIsDeterministic(t *testing.T) {
+	service := NewDashboardService()
+	fixed := time.Date(2026, 5, 31, 17, 0, 0, 0, time.UTC)
+	service.now = func() time.Time { return fixed }
+
+	service.UpsertNode(DashboardNode{ID: "node-b", Name: "B", Status: "online"})
+	service.UpsertNode(DashboardNode{ID: "node-a", Name: "A", Status: "offline"})
+	service.ReplaceAlerts([]Alert{
+		{ID: "old", CreatedAt: fixed.Add(-2 * time.Hour)},
+		{ID: "new", CreatedAt: fixed.Add(-1 * time.Minute)},
+	})
+
+	state := service.State()
+	if got := state.GeneratedAt; !got.Equal(fixed) {
+		t.Fatalf("GeneratedAt = %s, want %s", got, fixed)
+	}
+	if got := state.Nodes[0].ID; got != "node-a" {
+		t.Fatalf("first node = %s, want node-a", got)
+	}
+	if got := state.Alerts[0].ID; got != "new" {
+		t.Fatalf("first alert = %s, want new", got)
+	}
+}
+
+func TestCommandEndpointQueuesKnownNode(t *testing.T) {
+	service := NewDashboardService()
+	service.UpsertNode(DashboardNode{ID: "node-a", Name: "A", Status: "online"})
+	server := httptest.NewServer(service.Handler())
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"node_id":"node-a","type":"restart","payload":{"reason":"test"}}`)
+	response, err := http.Post(server.URL+"/fleet/command", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusAccepted)
+	}
+
+	var command Command
+	if err := json.NewDecoder(response.Body).Decode(&command); err != nil {
+		t.Fatal(err)
+	}
+	if command.Status != "pending" || command.NodeID != "node-a" || command.Type != "restart" {
+		t.Fatalf("unexpected command: %+v", command)
+	}
+	if got := service.State().Nodes[0].PendingCommands; got != 1 {
+		t.Fatalf("pending commands = %d, want 1", got)
+	}
+}
+
+func TestCommandEndpointRejectsUnknownNode(t *testing.T) {
+	service := NewDashboardService()
+	server := httptest.NewServer(service.Handler())
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"node_id":"missing","type":"restart"}`)
+	response, err := http.Post(server.URL+"/fleet/command", "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", response.StatusCode, http.StatusNotFound)
+	}
+}

--- a/web/dashboard/README.md
+++ b/web/dashboard/README.md
@@ -1,0 +1,36 @@
+# Fleet Dashboard
+
+This directory contains a dependency-free Fleet Manager dashboard for the Clawland bounty board task.
+
+## What it covers
+
+- Real-time style node status summary for online, degraded, and offline edge nodes.
+- Alert aggregation with critical, warning, and info severity states.
+- Command dispatch form for restart, config update, skill execution, and firmware update operations.
+- Geolocated node map using fixture coordinates.
+- Session-local command queue preview.
+- Fixture-backed data loading that can be replaced with Fleet Manager API responses later.
+
+## Local preview
+
+From the repository root:
+
+```sh
+python3 -m http.server 8088 -d web/dashboard
+```
+
+Then open `http://127.0.0.1:8088`.
+
+## API integration notes
+
+The dashboard currently loads `fixtures/fleet-state.json`. A production Fleet Manager can replace that fixture with an endpoint returning:
+
+```json
+{
+  "generated_at": "2026-05-31T17:00:00Z",
+  "nodes": [],
+  "alerts": []
+}
+```
+
+Commands are queued in the browser session today. When the command dispatch API is available, the submit handler in `app.js` can post `{ node_id, type, payload }` to `POST /fleet/command` and then render the returned command status.

--- a/web/dashboard/README.md
+++ b/web/dashboard/README.md
@@ -8,12 +8,20 @@ This directory contains a dependency-free Fleet Manager dashboard for the Clawla
 - Alert aggregation with critical, warning, and info severity states.
 - Command dispatch form for restart, config update, skill execution, and firmware update operations.
 - Geolocated node map using fixture coordinates.
-- Session-local command queue preview.
-- Fixture-backed data loading that can be replaced with Fleet Manager API responses later.
+- Command queue preview backed by `POST /fleet/command` when the Fleet Manager server is running.
+- API-backed data loading from `GET /fleet/dashboard/state`, with fixture fallback for static previews.
 
 ## Local preview
 
-From the repository root:
+With the Fleet Manager API and dashboard server:
+
+```sh
+go run ./cmd/fleet
+```
+
+Then open `http://127.0.0.1:8080`.
+
+For a static-only preview:
 
 ```sh
 python3 -m http.server 8088 -d web/dashboard
@@ -23,7 +31,7 @@ Then open `http://127.0.0.1:8088`.
 
 ## API integration notes
 
-The dashboard currently loads `fixtures/fleet-state.json`. A production Fleet Manager can replace that fixture with an endpoint returning:
+The dashboard first loads `GET /fleet/dashboard/state`, then falls back to `fixtures/fleet-state.json` for static previews. The state response is:
 
 ```json
 {
@@ -34,3 +42,12 @@ The dashboard currently loads `fixtures/fleet-state.json`. A production Fleet Ma
 ```
 
 Commands are queued in the browser session today. When the command dispatch API is available, the submit handler in `app.js` can post `{ node_id, type, payload }` to `POST /fleet/command` and then render the returned command status.
+Commands are submitted to `POST /fleet/command`:
+
+```json
+{
+  "node_id": "pond-a-picoclaw",
+  "type": "restart",
+  "payload": { "reason": "operator requested" }
+}
+```

--- a/web/dashboard/app.js
+++ b/web/dashboard/app.js
@@ -24,12 +24,23 @@ const els = {
 };
 
 async function loadFleetState() {
+  const response = await fetchFleetState();
+  state.data = response;
+  state.commands = response.commands ?? state.commands;
+  render();
+}
+
+async function fetchFleetState() {
+  const apiResponse = await fetch("/fleet/dashboard/state", { cache: "no-store" });
+  if (apiResponse.ok) {
+    return apiResponse.json();
+  }
+
   const response = await fetch("./fixtures/fleet-state.json", { cache: "no-store" });
   if (!response.ok) {
     throw new Error(`Unable to load fleet fixture: ${response.status}`);
   }
-  state.data = await response.json();
-  render();
+  return response.json();
 }
 
 function byStatus(status) {
@@ -152,7 +163,10 @@ function renderCommandQueue() {
       ? state.commands.map((command) => {
           const item = document.createElement("div");
           item.className = "queue-item";
-          item.textContent = `${command.type} queued for ${command.nodeId} at ${command.createdAt}`;
+          const createdAt = command.created_at
+            ? new Date(command.created_at).toLocaleTimeString()
+            : command.createdAt;
+          item.textContent = `${command.type} ${command.status ?? "queued"} for ${command.node_id ?? command.nodeId} at ${createdAt}`;
           return item;
         })
       : [emptyMessage("No commands queued in this browser session")]),
@@ -223,14 +237,45 @@ els.liveToggle.addEventListener("change", () => {
 
 els.commandForm.addEventListener("submit", (event) => {
   event.preventDefault();
-  state.commands.unshift({
-    nodeId: els.commandNode.value,
-    type: els.commandType.value,
-    payload: els.commandPayload.value,
-    createdAt: new Date().toLocaleTimeString(),
+  queueCommand().catch((error) => {
+    state.commands.unshift({
+      node_id: els.commandNode.value,
+      type: els.commandType.value,
+      payload: els.commandPayload.value,
+      status: "local",
+      created_at: new Date().toISOString(),
+      error: error.message,
+    });
+    renderCommandQueue();
   });
-  renderCommandQueue();
 });
+
+async function queueCommand() {
+  let payload;
+  try {
+    payload = els.commandPayload.value.trim() ? JSON.parse(els.commandPayload.value) : {};
+  } catch {
+    payload = { raw: els.commandPayload.value };
+  }
+
+  const response = await fetch("/fleet/command", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      node_id: els.commandNode.value,
+      type: els.commandType.value,
+      payload,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Command API returned ${response.status}`);
+  }
+  const command = await response.json();
+  state.commands.unshift(command);
+  renderCommandQueue();
+  await loadFleetState();
+}
 
 await loadFleetState();
 startPolling();

--- a/web/dashboard/app.js
+++ b/web/dashboard/app.js
@@ -1,0 +1,236 @@
+const state = {
+  filter: "all",
+  data: null,
+  commands: [],
+  pollTimer: null,
+};
+
+const els = {
+  onlineCount: document.querySelector("#onlineCount"),
+  degradedCount: document.querySelector("#degradedCount"),
+  offlineCount: document.querySelector("#offlineCount"),
+  criticalCount: document.querySelector("#criticalCount"),
+  lastUpdated: document.querySelector("#lastUpdated"),
+  nodeList: document.querySelector("#nodeList"),
+  alertList: document.querySelector("#alertList"),
+  mapCanvas: document.querySelector("#mapCanvas"),
+  commandNode: document.querySelector("#commandNode"),
+  commandType: document.querySelector("#commandType"),
+  commandPayload: document.querySelector("#commandPayload"),
+  commandForm: document.querySelector("#commandForm"),
+  commandQueue: document.querySelector("#commandQueue"),
+  liveToggle: document.querySelector("#liveToggle"),
+  refreshButton: document.querySelector("#refreshButton"),
+};
+
+async function loadFleetState() {
+  const response = await fetch("./fixtures/fleet-state.json", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Unable to load fleet fixture: ${response.status}`);
+  }
+  state.data = await response.json();
+  render();
+}
+
+function byStatus(status) {
+  return (node) => status === "all" || node.status === status;
+}
+
+function render() {
+  const data = state.data;
+  if (!data) return;
+
+  const nodes = data.nodes ?? [];
+  const alerts = data.alerts ?? [];
+  const counts = nodes.reduce(
+    (acc, node) => {
+      acc[node.status] = (acc[node.status] ?? 0) + 1;
+      return acc;
+    },
+    { online: 0, degraded: 0, offline: 0 },
+  );
+
+  els.onlineCount.textContent = counts.online;
+  els.degradedCount.textContent = counts.degraded;
+  els.offlineCount.textContent = counts.offline;
+  els.criticalCount.textContent = alerts.filter((alert) => alert.severity === "critical").length;
+  els.lastUpdated.textContent = `Updated ${formatRelative(data.generated_at)}`;
+
+  renderNodes(nodes.filter(byStatus(state.filter)));
+  renderAlerts(alerts);
+  renderMap(nodes);
+  renderCommandTargets(nodes);
+  renderCommandQueue();
+}
+
+function renderNodes(nodes) {
+  els.nodeList.replaceChildren(
+    ...(nodes.length
+      ? nodes.map((node) => {
+          const card = document.createElement("article");
+          card.className = "node-card";
+          card.innerHTML = `
+            <div>
+              <div class="node-title">
+                <span>${escapeHtml(node.name)}</span>
+                <span class="pill ${node.status}">${node.status}</span>
+              </div>
+              <div class="node-meta">
+                <span>${escapeHtml(node.type)}</span>
+                <span>${escapeHtml(node.location.name)}</span>
+                <span>${node.metrics.battery}% battery</span>
+              </div>
+            </div>
+            <div class="node-meta">
+              <span>${node.metrics.temperature_c}C</span>
+              <span>${node.metrics.signal_dbm} dBm</span>
+              <span>${node.pending_commands} queued</span>
+            </div>
+          `;
+          return card;
+        })
+      : [emptyMessage("No nodes match this filter")]),
+  );
+}
+
+function renderAlerts(alerts) {
+  els.alertList.replaceChildren(
+    ...(alerts.length
+      ? alerts.map((alert) => {
+          const card = document.createElement("article");
+          card.className = "alert-card";
+          card.innerHTML = `
+            <div class="alert-title">
+              <span>${escapeHtml(alert.title)}</span>
+              <span class="pill ${alert.severity}">${alert.severity}</span>
+            </div>
+            <p class="alert-time">${escapeHtml(alert.node_id)} - ${formatRelative(alert.created_at)}</p>
+          `;
+          return card;
+        })
+      : [emptyMessage("No open alerts")]),
+  );
+}
+
+function renderMap(nodes) {
+  els.mapCanvas.replaceChildren(
+    ...nodes.map((node) => {
+      const pin = document.createElement("button");
+      pin.type = "button";
+      pin.className = `pin ${node.status}`;
+      pin.style.left = `${node.location.map_x}%`;
+      pin.style.top = `${node.location.map_y}%`;
+      pin.title = `${node.name}: ${node.status}`;
+      pin.innerHTML = `<span>${escapeHtml(node.name)}</span>`;
+      pin.addEventListener("click", () => {
+        state.filter = node.status;
+        updateSegments();
+        render();
+      });
+      return pin;
+    }),
+  );
+}
+
+function renderCommandTargets(nodes) {
+  const current = els.commandNode.value;
+  els.commandNode.replaceChildren(
+    ...nodes.map((node) => {
+      const option = document.createElement("option");
+      option.value = node.id;
+      option.textContent = `${node.name} (${node.status})`;
+      option.disabled = node.status === "offline";
+      return option;
+    }),
+  );
+  if (current) els.commandNode.value = current;
+}
+
+function renderCommandQueue() {
+  els.commandQueue.replaceChildren(
+    ...(state.commands.length
+      ? state.commands.map((command) => {
+          const item = document.createElement("div");
+          item.className = "queue-item";
+          item.textContent = `${command.type} queued for ${command.nodeId} at ${command.createdAt}`;
+          return item;
+        })
+      : [emptyMessage("No commands queued in this browser session")]),
+  );
+}
+
+function emptyMessage(text) {
+  const node = document.createElement("div");
+  node.className = "empty";
+  node.textContent = text;
+  return node;
+}
+
+function setFilter(filter) {
+  state.filter = filter;
+  updateSegments();
+  render();
+}
+
+function updateSegments() {
+  document.querySelectorAll(".segment").forEach((button) => {
+    button.classList.toggle("active", button.dataset.filter === state.filter);
+  });
+}
+
+function startPolling() {
+  stopPolling();
+  state.pollTimer = window.setInterval(loadFleetState, 15000);
+}
+
+function stopPolling() {
+  if (state.pollTimer) {
+    window.clearInterval(state.pollTimer);
+    state.pollTimer = null;
+  }
+}
+
+function formatRelative(value) {
+  const timestamp = new Date(value).getTime();
+  const diffSeconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (diffSeconds < 60) return `${diffSeconds}s ago`;
+  const diffMinutes = Math.round(diffSeconds / 60);
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  return `${Math.round(diffMinutes / 60)}h ago`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+document.querySelectorAll(".segment").forEach((button) => {
+  button.addEventListener("click", () => setFilter(button.dataset.filter));
+});
+
+els.refreshButton.addEventListener("click", loadFleetState);
+
+els.liveToggle.addEventListener("change", () => {
+  if (els.liveToggle.checked) {
+    startPolling();
+  } else {
+    stopPolling();
+  }
+});
+
+els.commandForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  state.commands.unshift({
+    nodeId: els.commandNode.value,
+    type: els.commandType.value,
+    payload: els.commandPayload.value,
+    createdAt: new Date().toLocaleTimeString(),
+  });
+  renderCommandQueue();
+});
+
+await loadFleetState();
+startPolling();

--- a/web/dashboard/fixtures/fleet-state.json
+++ b/web/dashboard/fixtures/fleet-state.json
@@ -1,0 +1,108 @@
+{
+  "generated_at": "2026-05-31T17:00:00Z",
+  "nodes": [
+    {
+      "id": "pond-a-picoclaw",
+      "name": "Pond A Gateway",
+      "type": "picclaw",
+      "status": "online",
+      "pending_commands": 0,
+      "capabilities": ["aquaculture-monitoring", "mqtt", "edge-api"],
+      "location": {
+        "name": "North pond",
+        "lat": 37.781,
+        "lng": -122.404,
+        "map_x": 32,
+        "map_y": 48
+      },
+      "metrics": {
+        "battery": 92,
+        "temperature_c": 24.1,
+        "signal_dbm": -54
+      }
+    },
+    {
+      "id": "greenhouse-3-nanoclaw",
+      "name": "Greenhouse 3",
+      "type": "nanoclaw",
+      "status": "degraded",
+      "pending_commands": 2,
+      "capabilities": ["greenhouse", "relay-control", "camera"],
+      "location": {
+        "name": "West greenhouse",
+        "lat": 37.786,
+        "lng": -122.411,
+        "map_x": 58,
+        "map_y": 36
+      },
+      "metrics": {
+        "battery": 41,
+        "temperature_c": 31.6,
+        "signal_dbm": -82
+      }
+    },
+    {
+      "id": "cold-chain-van-12",
+      "name": "Van 12",
+      "type": "picclaw",
+      "status": "online",
+      "pending_commands": 1,
+      "capabilities": ["cold-chain", "gps", "audit-log"],
+      "location": {
+        "name": "Downtown route",
+        "lat": 37.774,
+        "lng": -122.419,
+        "map_x": 44,
+        "map_y": 66
+      },
+      "metrics": {
+        "battery": 77,
+        "temperature_c": 3.8,
+        "signal_dbm": -63
+      }
+    },
+    {
+      "id": "warehouse-door-2",
+      "name": "Warehouse Door 2",
+      "type": "microclaw",
+      "status": "offline",
+      "pending_commands": 0,
+      "capabilities": ["door-sensor", "pir"],
+      "location": {
+        "name": "Loading dock",
+        "lat": 37.769,
+        "lng": -122.398,
+        "map_x": 72,
+        "map_y": 55
+      },
+      "metrics": {
+        "battery": 12,
+        "temperature_c": 18.4,
+        "signal_dbm": -96
+      }
+    }
+  ],
+  "alerts": [
+    {
+      "id": "alert-001",
+      "node_id": "warehouse-door-2",
+      "severity": "critical",
+      "title": "Node missed three heartbeats",
+      "created_at": "2026-05-31T16:48:00Z"
+    },
+    {
+      "id": "alert-002",
+      "node_id": "greenhouse-3-nanoclaw",
+      "severity": "warning",
+      "title": "Signal quality below deployment threshold",
+      "created_at": "2026-05-31T16:54:00Z"
+    },
+    {
+      "id": "alert-003",
+      "node_id": "cold-chain-van-12",
+      "severity": "info",
+      "title": "Firmware update waiting for maintenance window",
+      "created_at": "2026-05-31T15:22:00Z"
+    }
+  ]
+}

--- a/web/dashboard/index.html
+++ b/web/dashboard/index.html
@@ -1,0 +1,117 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Clawland Fleet Dashboard</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header class="topbar">
+        <div>
+          <p class="eyebrow">MoltClaw Fleet Manager</p>
+          <h1>Fleet Dashboard</h1>
+        </div>
+        <div class="toolbar" aria-label="Dashboard controls">
+          <button class="icon-button" id="refreshButton" type="button" title="Refresh fleet data" aria-label="Refresh fleet data">
+            <span aria-hidden="true">R</span>
+          </button>
+          <label class="toggle">
+            <input id="liveToggle" type="checkbox" checked />
+            <span>Live</span>
+          </label>
+        </div>
+      </header>
+
+      <section class="metrics" aria-label="Fleet summary">
+        <article>
+          <span id="onlineCount">0</span>
+          <p>Online</p>
+        </article>
+        <article>
+          <span id="degradedCount">0</span>
+          <p>Degraded</p>
+        </article>
+        <article>
+          <span id="offlineCount">0</span>
+          <p>Offline</p>
+        </article>
+        <article>
+          <span id="criticalCount">0</span>
+          <p>Critical alerts</p>
+        </article>
+      </section>
+
+      <section class="main-grid">
+        <section class="panel fleet-panel" aria-labelledby="fleetTitle">
+          <div class="panel-heading">
+            <div>
+              <h2 id="fleetTitle">Nodes</h2>
+              <p id="lastUpdated">Waiting for data</p>
+            </div>
+            <div class="segmented" role="group" aria-label="Filter nodes by status">
+              <button class="segment active" type="button" data-filter="all">All</button>
+              <button class="segment" type="button" data-filter="online">Online</button>
+              <button class="segment" type="button" data-filter="degraded">Degraded</button>
+              <button class="segment" type="button" data-filter="offline">Offline</button>
+            </div>
+          </div>
+          <div class="node-list" id="nodeList" aria-live="polite"></div>
+        </section>
+
+        <section class="panel map-panel" aria-labelledby="mapTitle">
+          <div class="panel-heading">
+            <div>
+              <h2 id="mapTitle">Map</h2>
+              <p>Geolocated node health</p>
+            </div>
+          </div>
+          <div class="map" id="mapCanvas" role="img" aria-label="Map showing fleet node positions"></div>
+        </section>
+
+        <section class="panel alerts-panel" aria-labelledby="alertsTitle">
+          <div class="panel-heading">
+            <div>
+              <h2 id="alertsTitle">Alerts</h2>
+              <p>Open incidents grouped by severity</p>
+            </div>
+          </div>
+          <div class="alert-list" id="alertList" aria-live="polite"></div>
+        </section>
+
+        <section class="panel command-panel" aria-labelledby="commandTitle">
+          <div class="panel-heading">
+            <div>
+              <h2 id="commandTitle">Command Dispatch</h2>
+              <p>Queue cloud-to-edge commands</p>
+            </div>
+          </div>
+          <form id="commandForm" class="command-form">
+            <label>
+              Node
+              <select id="commandNode" required></select>
+            </label>
+            <label>
+              Command
+              <select id="commandType" required>
+                <option value="restart">Restart</option>
+                <option value="update_config">Update config</option>
+                <option value="execute_skill">Execute skill</option>
+                <option value="firmware_update">Firmware update</option>
+              </select>
+            </label>
+            <label>
+              Payload
+              <textarea id="commandPayload" rows="5" spellcheck="false">{ "reason": "operator requested" }</textarea>
+            </label>
+            <button class="primary" type="submit">Queue command</button>
+          </form>
+          <div class="queue" id="commandQueue" aria-live="polite"></div>
+        </section>
+      </section>
+    </main>
+
+    <script src="./app.js" type="module"></script>
+  </body>
+</html>

--- a/web/dashboard/styles.css
+++ b/web/dashboard/styles.css
@@ -1,0 +1,406 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7f4;
+  --panel: #ffffff;
+  --text: #17201b;
+  --muted: #667066;
+  --line: #dce2db;
+  --accent: #28705f;
+  --accent-strong: #174d42;
+  --warning: #c77924;
+  --danger: #b4323c;
+  --info: #3d6691;
+  --shadow: 0 18px 42px rgba(25, 42, 36, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+button,
+select,
+textarea {
+  font: inherit;
+}
+
+.shell {
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.topbar,
+.metrics,
+.main-grid {
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 34px;
+  line-height: 1.1;
+}
+
+h2 {
+  font-size: 18px;
+  line-height: 1.2;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.icon-button,
+.primary,
+.segment {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.icon-button {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border-radius: 8px;
+  font-weight: 800;
+}
+
+.toggle {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.metrics article,
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.metrics article {
+  padding: 18px;
+}
+
+.metrics span {
+  display: block;
+  font-size: 30px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.metrics p,
+.panel-heading p,
+.node-meta,
+.queue-item,
+.alert-time {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.main-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.85fr);
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.panel {
+  min-width: 0;
+  padding: 16px;
+}
+
+.fleet-panel {
+  grid-row: span 2;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.segment {
+  min-height: 34px;
+  padding: 0 10px;
+  border-radius: 8px;
+  color: var(--muted);
+}
+
+.segment.active {
+  border-color: var(--accent);
+  background: #e4f2ee;
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.node-list,
+.alert-list,
+.queue {
+  display: grid;
+  gap: 10px;
+}
+
+.node-card,
+.alert-card,
+.queue-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  background: #fbfcfb;
+}
+
+.node-card {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+}
+
+.node-title,
+.alert-title {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-weight: 800;
+}
+
+.node-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.pill {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0 9px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.online {
+  background: #dff4e7;
+  color: #1d6b3b;
+}
+
+.degraded {
+  background: #fff0d8;
+  color: #8a5418;
+}
+
+.offline,
+.critical {
+  background: #fde2e4;
+  color: #9e2831;
+}
+
+.warning {
+  background: #fff0d8;
+  color: #8a5418;
+}
+
+.info {
+  background: #e3edf8;
+  color: #315c87;
+}
+
+.map {
+  position: relative;
+  min-height: 360px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background:
+    linear-gradient(90deg, rgba(40, 112, 95, 0.08) 1px, transparent 1px),
+    linear-gradient(rgba(40, 112, 95, 0.08) 1px, transparent 1px),
+    linear-gradient(135deg, #e9f4f0, #f8fbf8 55%, #e8eef4);
+  background-size: 34px 34px, 34px 34px, auto;
+}
+
+.map::before {
+  position: absolute;
+  inset: 24px;
+  border: 1px dashed rgba(40, 112, 95, 0.26);
+  border-radius: 999px;
+  content: "";
+}
+
+.pin {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 3px solid #fff;
+  border-radius: 50%;
+  box-shadow: 0 8px 20px rgba(23, 32, 27, 0.22);
+  transform: translate(-50%, -50%);
+}
+
+.pin.online {
+  background: #2e8f55;
+}
+
+.pin.degraded {
+  background: var(--warning);
+}
+
+.pin.offline {
+  background: var(--danger);
+}
+
+.pin span {
+  position: absolute;
+  left: 14px;
+  top: -5px;
+  min-width: 110px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.command-form {
+  display: grid;
+  gap: 10px;
+}
+
+.command-form label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcfb;
+  color: var(--text);
+  padding: 10px;
+}
+
+textarea {
+  min-height: 116px;
+  resize: vertical;
+}
+
+.primary {
+  min-height: 42px;
+  border-color: var(--accent);
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 800;
+}
+
+.queue {
+  margin-top: 12px;
+}
+
+.empty {
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  padding: 16px;
+  color: var(--muted);
+  text-align: center;
+}
+
+@media (max-width: 980px) {
+  .metrics,
+  .main-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .fleet-panel {
+    grid-row: auto;
+  }
+
+  .node-meta {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .shell {
+    padding: 14px;
+  }
+
+  .topbar,
+  .panel-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  h1 {
+    font-size: 28px;
+  }
+
+  .segmented {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
Fleet Manager Dashboard bounty board submission ($600).

Summary:
- add a dependency-free Fleet Manager dashboard under web/dashboard
- show real-time style node status counts, status filtering, alert aggregation, and geolocated node pins
- add command dispatch controls with a session-local queue for restart, config update, skill execution, and firmware update commands
- include a sample fleet snapshot fixture and dashboard README with local preview and API integration notes
- link the root README to the dashboard preview workflow

Validation:
- node --check web/dashboard/app.js
- JSON fixture parse check passed
- go test ./...
- git diff --check
- local static server smoke: http://127.0.0.1:8088/ and /fixtures/fleet-state.json returned 200

Bounty board reference: https://clawland.ai/pages/bounty

Payment/association note: the public bounty board lists this as the Fleet Manager Dashboard bounty for $600, but I do not see a matching GitHub bounty issue in this repository. This PR is intended to claim that bounty-board item; please let me know if maintainers want it linked to a specific tracking issue.