### PR TITLE
feat: add fleet node registration and heartbeat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,59 @@ Clawland Fleet is the **nervous system** connecting cloud and edge. It provides 
 - **Batch Upload** — Compress and send sensor data on schedule
 - **Offline Buffer** — Store-and-forward when connectivity is lost
 
+## Fleet Manager API
+
+Start the HTTP service:
+
+```bash
+go run ./cmd/fleet
+```
+
+Set `PORT` to listen on a different port:
+
+```bash
+PORT=9090 go run ./cmd/fleet
+```
+
+Register an edge node:
+
+```bash
+curl -X POST http://localhost:8080/fleet/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "node_id": "picclaw-1",
+    "type": "picclaw",
+    "capabilities": ["temperature", "humidity"],
+    "location": "greenhouse-a"
+  }'
+```
+
+Send a heartbeat with status and metrics:
+
+```bash
+curl -X POST http://localhost:8080/fleet/heartbeat \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "node_id": "picclaw-1",
+    "status": "online",
+    "metrics": {"cpu": 0.41, "battery": 0.87}
+  }'
+```
+
+List all nodes, or filter by status:
+
+```bash
+curl http://localhost:8080/fleet/nodes
+curl http://localhost:8080/fleet/nodes?status=online
+curl http://localhost:8080/fleet/nodes?status=offline
+```
+
+Read a single node:
+
+```bash
+curl http://localhost:8080/fleet/nodes/picclaw-1
+```
+
 ## Architecture
 
 ```

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -6,20 +6,28 @@ package main
 import (
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+
+	"github.com/Clawland-AI/clawland-fleet/pkg/fleet"
 )
 
 const version = "0.1.0"
 
 func main() {
-	port := os.Getenv("PORT")
+	addr := listenAddress(os.Getenv("PORT"))
+
+	fmt.Printf("Clawland Fleet Manager v%s\n", version)
+	fmt.Printf("   Cloud-Edge orchestration starting on %s...\n", addr)
+	fmt.Println("   Waiting for edge agent registrations...")
+
+	log.Printf("Fleet Manager listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, fleet.NewServer(fleet.NewRegistry())))
+}
+
+func listenAddress(port string) string {
 	if port == "" {
 		port = "8080"
 	}
-
-	fmt.Printf("馃 Clawland Fleet Manager v%s\n", version)
-	fmt.Printf("   Cloud-Edge orchestration starting on :%s...\n", port)
-	fmt.Println("   Waiting for edge agent registrations...")
-
-	log.Printf("Fleet Manager listening on :%s", port)
+	return ":" + port
 }

--- a/cmd/fleet/main_test.go
+++ b/cmd/fleet/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func TestListenAddressUsesDefaultPort(t *testing.T) {
+	if got := listenAddress(""); got != ":8080" {
+		t.Fatalf("expected default address :8080, got %q", got)
+	}
+}
+
+func TestListenAddressUsesConfiguredPort(t *testing.T) {
+	if got := listenAddress("9090"); got != ":9090" {
+		t.Fatalf("expected configured address :9090, got %q", got)
+	}
+}

--- a/pkg/fleet/registry.go
+++ b/pkg/fleet/registry.go
@@ -8,55 +8,134 @@ import (
 
 // Node represents a registered edge agent.
 type Node struct {
-	ID           string            `json:"id"`
-	Name         string            `json:"name"`
-	Type         string            `json:"type"` // picclaw, nanoclaw, microclaw
-	Capabilities []string          `json:"capabilities"`
-	Location     string            `json:"location,omitempty"`
-	LastSeen     time.Time         `json:"last_seen"`
-	Status       string            `json:"status"` // online, offline, degraded
-	Metadata     map[string]string `json:"metadata,omitempty"`
+	ID           string             `json:"id"`
+	Name         string             `json:"name"`
+	Type         string             `json:"type"` // picclaw, nanoclaw, microclaw
+	Capabilities []string           `json:"capabilities"`
+	Location     string             `json:"location,omitempty"`
+	LastSeen     time.Time          `json:"last_seen"`
+	Status       string             `json:"status"` // online, offline, degraded
+	Metrics      map[string]float64 `json:"metrics,omitempty"`
+	Metadata     map[string]string  `json:"metadata,omitempty"`
 }
 
 // Registry manages registered edge nodes.
 type Registry struct {
-	mu    sync.RWMutex
-	nodes map[string]*Node
+	mu               sync.RWMutex
+	nodes            map[string]*Node
+	heartbeatTimeout time.Duration
 }
+
+const defaultHeartbeatTimeout = 2 * time.Minute
 
 // NewRegistry creates a new node registry.
 func NewRegistry() *Registry {
-	return &Registry{nodes: make(map[string]*Node)}
+	return NewRegistryWithHeartbeatTimeout(defaultHeartbeatTimeout)
+}
+
+// NewRegistryWithHeartbeatTimeout creates a registry with a custom offline timeout.
+func NewRegistryWithHeartbeatTimeout(timeout time.Duration) *Registry {
+	if timeout <= 0 {
+		timeout = defaultHeartbeatTimeout
+	}
+	return &Registry{nodes: make(map[string]*Node), heartbeatTimeout: timeout}
 }
 
 // Register adds or updates a node in the registry.
-func (r *Registry) Register(node *Node) {
+func (r *Registry) Register(node *Node) *Node {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	node.LastSeen = time.Now()
-	node.Status = "online"
-	r.nodes[node.ID] = node
+	stored := cloneNode(node)
+	stored.LastSeen = time.Now()
+	stored.Status = "online"
+	r.nodes[stored.ID] = stored
+	return cloneNode(stored)
 }
 
 // Heartbeat updates the last seen time for a node.
 func (r *Registry) Heartbeat(nodeID string) bool {
+	_, ok := r.UpdateHeartbeat(nodeID, "online", nil)
+	return ok
+}
+
+// UpdateHeartbeat updates node status, metrics, and last seen time.
+func (r *Registry) UpdateHeartbeat(nodeID string, status string, metrics map[string]float64) (*Node, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if n, ok := r.nodes[nodeID]; ok {
 		n.LastSeen = time.Now()
-		n.Status = "online"
-		return true
+		if status == "" {
+			status = "online"
+		}
+		n.Status = status
+		if metrics != nil {
+			n.Metrics = cloneFloatMap(metrics)
+		}
+		return cloneNode(n), true
 	}
-	return false
+	return nil, false
+}
+
+// Get returns a registered node by ID.
+func (r *Registry) Get(nodeID string) (*Node, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refreshStatusesLocked(time.Now())
+	n, ok := r.nodes[nodeID]
+	if !ok {
+		return nil, false
+	}
+	return cloneNode(n), true
 }
 
 // List returns all registered nodes.
 func (r *Registry) List() []*Node {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refreshStatusesLocked(time.Now())
 	nodes := make([]*Node, 0, len(r.nodes))
 	for _, n := range r.nodes {
-		nodes = append(nodes, n)
+		nodes = append(nodes, cloneNode(n))
 	}
 	return nodes
+}
+
+func (r *Registry) refreshStatusesLocked(now time.Time) {
+	for _, node := range r.nodes {
+		if node.Status == "offline" {
+			continue
+		}
+		if now.Sub(node.LastSeen) > r.heartbeatTimeout {
+			node.Status = "offline"
+		}
+	}
+}
+
+func cloneNode(node *Node) *Node {
+	if node == nil {
+		return &Node{}
+	}
+	clone := *node
+	if node.Capabilities != nil {
+		clone.Capabilities = append([]string(nil), node.Capabilities...)
+	}
+	clone.Metrics = cloneFloatMap(node.Metrics)
+	if node.Metadata != nil {
+		clone.Metadata = make(map[string]string, len(node.Metadata))
+		for key, value := range node.Metadata {
+			clone.Metadata[key] = value
+		}
+	}
+	return &clone
+}
+
+func cloneFloatMap(values map[string]float64) map[string]float64 {
+	if values == nil {
+		return nil
+	}
+	clone := make(map[string]float64, len(values))
+	for key, value := range values {
+		clone[key] = value
+	}
+	return clone
 }

--- a/pkg/fleet/server.go
+++ b/pkg/fleet/server.go
@@ -1,0 +1,167 @@
+package fleet
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// NewServer builds the Fleet Manager HTTP API.
+func NewServer(registry *Registry) http.Handler {
+	if registry == nil {
+		registry = NewRegistry()
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/fleet/register", handleRegister(registry))
+	mux.HandleFunc("/fleet/heartbeat", handleHeartbeat(registry))
+	mux.HandleFunc("/fleet/nodes", handleListNodes(registry))
+	mux.HandleFunc("/fleet/nodes/", handleGetNode(registry))
+	return mux
+}
+
+type registerRequest struct {
+	NodeID       string            `json:"node_id"`
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Type         string            `json:"type"`
+	Capabilities []string          `json:"capabilities"`
+	Location     string            `json:"location"`
+	Metadata     map[string]string `json:"metadata"`
+}
+
+type heartbeatRequest struct {
+	NodeID  string             `json:"node_id"`
+	ID      string             `json:"id"`
+	Status  string             `json:"status"`
+	Metrics map[string]float64 `json:"metrics"`
+}
+
+func handleRegister(registry *Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w)
+			return
+		}
+
+		var req registerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON payload")
+			return
+		}
+
+		id := strings.TrimSpace(req.NodeID)
+		if id == "" {
+			id = strings.TrimSpace(req.ID)
+		}
+		if id == "" {
+			writeError(w, http.StatusBadRequest, "node_id is required")
+			return
+		}
+
+		node := &Node{
+			ID:           id,
+			Name:         req.Name,
+			Type:         req.Type,
+			Capabilities: req.Capabilities,
+			Location:     req.Location,
+			Metadata:     req.Metadata,
+		}
+		registered := registry.Register(node)
+
+		writeJSON(w, http.StatusCreated, registered)
+	}
+}
+
+func handleHeartbeat(registry *Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w)
+			return
+		}
+
+		var req heartbeatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON payload")
+			return
+		}
+
+		id := strings.TrimSpace(req.NodeID)
+		if id == "" {
+			id = strings.TrimSpace(req.ID)
+		}
+		if id == "" {
+			writeError(w, http.StatusBadRequest, "node_id is required")
+			return
+		}
+
+		node, ok := registry.UpdateHeartbeat(id, strings.TrimSpace(req.Status), req.Metrics)
+		if !ok {
+			writeError(w, http.StatusNotFound, "node not found")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, node)
+	}
+}
+
+func handleListNodes(registry *Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w)
+			return
+		}
+
+		status := strings.TrimSpace(r.URL.Query().Get("status"))
+		nodes := registry.List()
+		if status != "" {
+			filtered := nodes[:0]
+			for _, node := range nodes {
+				if node.Status == status {
+					filtered = append(filtered, node)
+				}
+			}
+			nodes = filtered
+		}
+
+		writeJSON(w, http.StatusOK, nodes)
+	}
+}
+
+func handleGetNode(registry *Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w)
+			return
+		}
+
+		nodeID := strings.TrimPrefix(r.URL.Path, "/fleet/nodes/")
+		nodeID = strings.TrimSpace(nodeID)
+		if nodeID == "" {
+			writeError(w, http.StatusNotFound, "node not found")
+			return
+		}
+
+		node, ok := registry.Get(nodeID)
+		if !ok {
+			writeError(w, http.StatusNotFound, "node not found")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, node)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"error": message})
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+}

--- a/pkg/fleet/server_test.go
+++ b/pkg/fleet/server_test.go
@@ -1,0 +1,146 @@
+package fleet
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestServerRegistersNodeAndListsOnlineNodes(t *testing.T) {
+	handler := NewServer(NewRegistry())
+
+	body := bytes.NewBufferString(`{
+		"node_id": "picclaw-1",
+		"name": "greenhouse edge",
+		"type": "picclaw",
+		"capabilities": ["temp", "humidity"],
+		"location": "greenhouse-a"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/fleet/register", body)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusCreated, rec.Code, rec.Body.String())
+	}
+
+	var created Node
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatalf("decode register response: %v", err)
+	}
+	if created.ID != "picclaw-1" || created.Status != "online" || created.LastSeen.IsZero() {
+		t.Fatalf("unexpected register response: %+v", created)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/fleet/nodes?status=online", nil)
+	rec = httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var nodes []Node
+	if err := json.NewDecoder(rec.Body).Decode(&nodes); err != nil {
+		t.Fatalf("decode nodes response: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 online node, got %d", len(nodes))
+	}
+	if nodes[0].ID != "picclaw-1" || nodes[0].Status != "online" {
+		t.Fatalf("unexpected node: %+v", nodes[0])
+	}
+}
+
+func TestServerHeartbeatUpdatesStatusAndMetrics(t *testing.T) {
+	handler := NewServer(NewRegistry())
+	registerNode(t, handler, `{"node_id":"picclaw-1","type":"picclaw"}`)
+
+	body := bytes.NewBufferString(`{
+		"node_id": "picclaw-1",
+		"status": "degraded",
+		"metrics": {"cpu": 0.71, "battery": 0.42}
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/fleet/heartbeat", body)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/fleet/nodes/picclaw-1", nil)
+	rec = httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var node Node
+	if err := json.NewDecoder(rec.Body).Decode(&node); err != nil {
+		t.Fatalf("decode node response: %v", err)
+	}
+	if node.Status != "degraded" {
+		t.Fatalf("expected node status degraded, got %q", node.Status)
+	}
+	if node.Metrics["cpu"] != 0.71 || node.Metrics["battery"] != 0.42 {
+		t.Fatalf("unexpected metrics: %+v", node.Metrics)
+	}
+}
+
+func TestRegistryMarksNodeOfflineAfterHeartbeatTimeout(t *testing.T) {
+	registry := NewRegistryWithHeartbeatTimeout(5 * time.Millisecond)
+	registry.Register(&Node{ID: "picclaw-1"})
+
+	time.Sleep(10 * time.Millisecond)
+
+	nodes := registry.List()
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+	if nodes[0].Status != "offline" {
+		t.Fatalf("expected node to be offline after timeout, got %q", nodes[0].Status)
+	}
+}
+
+func TestServerRejectsInvalidRegisterPayloads(t *testing.T) {
+	handler := NewServer(NewRegistry())
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "invalid json", payload: `{`},
+		{name: "missing node id", payload: `{"type":"picclaw"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/fleet/register", bytes.NewBufferString(tc.payload))
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected status %d, got %d with body %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func registerNode(t *testing.T, handler http.Handler, payload string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/fleet/register", bytes.NewBufferString(payload))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register node status %d, body %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Implements the Fleet Manager node registration and heartbeat HTTP API:

- `POST /fleet/register` registers or updates edge nodes with capabilities and location
- `POST /fleet/heartbeat` updates `last_seen`, status, and metrics
- `GET /fleet/nodes` lists nodes, with optional `?status=online|offline|degraded` filtering
- `GET /fleet/nodes/{id}` returns a single node
- In-memory registry now marks nodes offline after a heartbeat timeout and returns cloned node snapshots
- `cmd/fleet` now starts the HTTP server instead of only logging startup text
- README includes run and curl examples

## Validation

- `go test ./...`
- `go test -race ./pkg/fleet`
- `go build ./...`
- `go vet ./...`
- Manual HTTP smoke test with `go run ./cmd/fleet`, `POST /fleet/register`, `POST /fleet/heartbeat`, and `GET /fleet/nodes?status=online`

## Note

This addresses `feat: implement node registration and heartbeat service` in `Clawland-AI/clawland-fleet#2`.
